### PR TITLE
Fixing off-by-one error in Jump Bridge Clipboard import.

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1469,7 +1469,7 @@ namespace SMT
                         }
 
                         string[] bits = line.Split(' ');
-                        if (bits.Length > 3)
+                        if (bits.Length > 2)
                         {
                             int test = 1;
                             test++;
@@ -1477,8 +1477,8 @@ namespace SMT
                             long IDFrom = 0;
                             long.TryParse(bits[0], out IDFrom);
 
-                            string from = bits[1];
-                            string to = bits[3];
+                            string from = bits[0];
+                            string to = bits[2];
 
                             EVEManager.AddUpdateJumpBridge(from, to, IDFrom);
                         }


### PR DESCRIPTION
Fixes #30 

I was curious when you closed that issue as I thought I'd tried that. When I dug a bit deeper, I saw you had an off-by-one error in the clipboard import for jump bridges. I fixed this error on my fork, and when I copied in the format you specified, the jump bridges were added from the clipboard just as you said they'd be. (Bonus is that I was able to copy that JumpBridges.dat to the current stable version too).