### PR TITLE
Per-Monitor DPI awareness

### DIFF
--- a/EVEData/EveManager.cs
+++ b/EVEData/EveManager.cs
@@ -24,6 +24,7 @@ using System.Windows.Media;
 using System.Windows.Threading;
 using System.Xml;
 using System.Xml.Serialization;
+using System.Globalization;
 
 namespace SMT.EVEData
 {
@@ -300,6 +301,9 @@ namespace SMT.EVEData
         /// </summary>
         public void CreateFromScratch()
         {
+            // allow parsing to work for all locales (comma/dot in csv float)
+            Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+
             Regions = new List<MapRegion>();
 
             // manually add the regions we care about

--- a/app.manifest
+++ b/app.manifest
@@ -49,13 +49,13 @@
        DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
        to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
        also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. -->
-  <!--
+	
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
       <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
     </windowsSettings>
   </application>
-  -->
 
   <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
   <!--


### PR DESCRIPTION
Small fix, just getting started with the project 😃

The default WPF behaviour is DPI aware but using the system-wide DPI, not the one configured for each monitor.
Tested this on my monitors and a subtle change can be seen, especially on labels (for exemple, ther vertical tabs on the right).

Should fix #56.

Before :
![non dpi aware](https://user-images.githubusercontent.com/940586/131145047-66359f96-10aa-48df-85ed-3db450ae766b.png)


After :
![dpi aware](https://user-images.githubusercontent.com/940586/131144636-a10ce3ca-f82e-43db-891d-d97bcdbd190f.png)
