### PR TITLE
Changed resizing behaviour to disable snapping while moving. 

### DIFF
--- a/SMT/Overlay.xaml.cs
+++ b/SMT/Overlay.xaml.cs
@@ -1306,7 +1306,13 @@ namespace SMT
         {
             if (e.ChangedButton == MouseButton.Left)
             {
+                // This is a quick way to avoid snapping by just disallowing the resizing during drag.
+                this.ResizeMode = ResizeMode.NoResize;
+
                 this.DragMove();
+
+                // Since this not asynchronous, we can just restore the resizing here.
+                this.ResizeMode = ResizeMode.CanResizeWithGrip;
             }
             e.Handled = true;
         }


### PR DESCRIPTION
Added a compact fix to disable resizing while the overlay window is being moved. This effectively disables snapping by dragging the window to the screen borders. It does NOT disable snapping by hotkeys or snapping by using the resize grip and dragging the corner to one of the screen borders.