### PR TITLE
Misc Changes: View Locator, .NET Analyzers

### DIFF
--- a/EVEData/EVEData.csproj
+++ b/EVEData/EVEData.csproj
@@ -6,7 +6,8 @@
     <Nullable>disable</Nullable>
     <RunAnalyzersDuringBuild>False</RunAnalyzersDuringBuild>
     <RunAnalyzersDuringLiveAnalysis>False</RunAnalyzersDuringLiveAnalysis>
-    <EnableNETAnalyzers>False</EnableNETAnalyzers>
+	  <EnableNETAnalyzers>true</EnableNETAnalyzers>
+	  <AnalysisMode>All</AnalysisMode>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SMT/SMT.csproj
+++ b/SMT/SMT.csproj
@@ -180,11 +180,6 @@
     <Resource Include="Images\overlay_hunter.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="DesktopNotifications" Version="1.2.0" />
-    <PackageReference Include="DesktopNotifications.Apple" Version="1.2.0" />
-    <PackageReference Include="DesktopNotifications.Avalonia" Version="1.2.0" />
-    <PackageReference Include="DesktopNotifications.FreeDesktop" Version="1.2.0" />
-    <PackageReference Include="DesktopNotifications.Windows" Version="1.2.0" />
     <PackageReference Include="Dirkster.AvalonDock.Themes.Expression">
       <Version>4.72.0</Version>
     </PackageReference>

--- a/SMT/SMT.csproj
+++ b/SMT/SMT.csproj
@@ -47,7 +47,8 @@
     <AnalysisLevel>latest-all</AnalysisLevel>
     <PlatformTarget>x64</PlatformTarget>
     <EnforceCodeStyleInBuild>False</EnforceCodeStyleInBuild>
-    <EnableNETAnalyzers>False</EnableNETAnalyzers>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+	 <AnalysisMode>All</AnalysisMode>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <OutputPath>bin\x64\Debug\</OutputPath>
@@ -179,6 +180,11 @@
     <Resource Include="Images\overlay_hunter.png" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="DesktopNotifications" Version="1.2.0" />
+    <PackageReference Include="DesktopNotifications.Apple" Version="1.2.0" />
+    <PackageReference Include="DesktopNotifications.Avalonia" Version="1.2.0" />
+    <PackageReference Include="DesktopNotifications.FreeDesktop" Version="1.2.0" />
+    <PackageReference Include="DesktopNotifications.Windows" Version="1.2.0" />
     <PackageReference Include="Dirkster.AvalonDock.Themes.Expression">
       <Version>4.72.0</Version>
     </PackageReference>

--- a/SMTx/App.axaml
+++ b/SMTx/App.axaml
@@ -6,6 +6,10 @@
              Name="Dock Avalonia Demo"
              x:Class="SMTx.App">
 
+	<Application.DataTemplates>
+		<local:ViewLocator />
+	</Application.DataTemplates>
+
 
   <Application.Styles>
 

--- a/SMTx/SMTx.csproj
+++ b/SMTx/SMTx.csproj
@@ -21,6 +21,11 @@
 	<TrimmableAssembly Include="Avalonia.Themes.Default" />
   </ItemGroup>
   <ItemGroup>
+	<PackageReference Include="DesktopNotifications" Version="1.2.0" />
+	<PackageReference Include="DesktopNotifications.Apple" Version="1.2.0" />
+	<PackageReference Include="DesktopNotifications.Avalonia" Version="1.2.0" />
+	<PackageReference Include="DesktopNotifications.FreeDesktop" Version="1.2.0" />
+	<PackageReference Include="DesktopNotifications.Windows" Version="1.2.0" />
     <PackageReference Include="Avalonia" Version="11.0.0-preview6" />
     <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview6" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->

--- a/SMTx/SMTx.csproj
+++ b/SMTx/SMTx.csproj
@@ -6,6 +6,8 @@
 	<!--Avalonia doesen't support TrimMode=link currently,but we are working on that https://github.com/AvaloniaUI/Avalonia/issues/6892 -->
 	<TrimMode>copyused</TrimMode>
 	<BuiltInComInteropSupport>true</BuiltInComInteropSupport>
+	  <EnableNETAnalyzers>true</EnableNETAnalyzers>
+	  <AnalysisMode>All</AnalysisMode>
   </PropertyGroup>
   <ItemGroup>
     <AvaloniaResource Include="Assets\**" />

--- a/Utils/Utils.csproj
+++ b/Utils/Utils.csproj
@@ -6,7 +6,8 @@
     <Nullable>disable</Nullable>
     <EnforceCodeStyleInBuild>False</EnforceCodeStyleInBuild>
     <RunAnalyzersDuringBuild>False</RunAnalyzersDuringBuild>
-    <EnableNETAnalyzers>False</EnableNETAnalyzers>
+	  <EnableNETAnalyzers>true</EnableNETAnalyzers>
+	  <AnalysisMode>All</AnalysisMode>
 
   </PropertyGroup>
 


### PR DESCRIPTION
This pull request contains a change for Avalonia development, and two changes that are necessary for general cross-platform development.

This includes adding the View Locator to inflate the panel views in the app. The View Locator was created, but it was not being used in the app.axaml.

This also includes desktop notification libraries to initiate cross-platform development of notifications, as well as Microsoft Analyzers to detect issues with cross-platform compatibility. The analyzers may be stripped out during Release builds or removed from the repository after cross-platform development is completed.