### PR TITLE
Feature: Add player alerting ability for intel channels

### DIFF
--- a/EVEData/EveAppConfig.cs
+++ b/EVEData/EveAppConfig.cs
@@ -23,7 +23,7 @@ namespace SMT.EVEData
         /// <summary>
         /// SMT Version Tagline
         /// </summary>
-        public const string SMT_TITLE = "pilot538 BETA";
+        public const string SMT_TITLE = "Status ? Best not to ask..";
 
         /// <summary>
         /// SMT Version

--- a/EVEData/EveAppConfig.cs
+++ b/EVEData/EveAppConfig.cs
@@ -23,7 +23,7 @@ namespace SMT.EVEData
         /// <summary>
         /// SMT Version Tagline
         /// </summary>
-        public const string SMT_TITLE = "Status ? Best not to ask..";
+        public const string SMT_TITLE = "pilot538 BETA";
 
         /// <summary>
         /// SMT Version

--- a/EVEData/EveManager.cs
+++ b/EVEData/EveManager.cs
@@ -338,6 +338,11 @@ namespace SMT.EVEData
         public List<string> IntelIgnoreFilters { get; set; }
 
         /// <summary>
+        /// Gets or sets the current list of alerting intel market for intel (eg "pilot538 Maken")
+        /// </summary>
+        public List<string> IntelAlertFilters { get; set; }
+
+        /// <summary>
         /// Gets or sets the Name to System dictionary
         /// </summary>
         private Dictionary<string, System> NameToSystem { get; }
@@ -1849,6 +1854,7 @@ namespace SMT.EVEData
             File.WriteAllLines(Path.Combine(SaveDataRootFolder, "IntelChannels.txt"), IntelFilters);
             File.WriteAllLines(Path.Combine(SaveDataRootFolder, "IntelClearFilters.txt"), IntelClearFilters);
             File.WriteAllLines(Path.Combine(SaveDataRootFolder, "IntelIgnoreFilters.txt"), IntelIgnoreFilters);
+            File.WriteAllLines(Path.Combine(SaveDataRootFolder, "IntelAlertFilters.txt"), IntelAlertFilters);
             File.WriteAllLines(Path.Combine(SaveDataRootFolder, "CynoBeacons.txt"), beaconsToSave);
         }
 
@@ -1925,6 +1931,28 @@ namespace SMT.EVEData
             {
                 // default
                 IntelIgnoreFilters.Add("Status");
+            }
+
+            IntelAlertFilters = new List<string>();
+            string intelAlertFileFilter = Path.Combine(SaveDataRootFolder, "IntelAlertFilters.txt");
+
+            if (File.Exists(intelAlertFileFilter))
+            {
+                StreamReader file = new StreamReader(intelAlertFileFilter);
+                string line;
+                while ((line = file.ReadLine()) != null)
+                {
+                    line = line.Trim();
+                    if (!string.IsNullOrEmpty(line))
+                    {
+                        IntelAlertFilters.Add(line);
+                    }
+                }
+            }
+            else
+            {
+                // default, alert on nothing
+                IntelAlertFilters.Add("");
             }
 
             intelFileReadPos = new Dictionary<string, int>();

--- a/SMT/MainWindow.xaml.cs
+++ b/SMT/MainWindow.xaml.cs
@@ -40,6 +40,8 @@ namespace SMT
 
         private List<InfoItem> InfoLayer;
 
+        private List<string> playerAlertNames;
+
         private Dictionary<string, long> CharacterNameIDCache;
         private Dictionary<long, string> CharacterIDNameCache;
 
@@ -155,8 +157,16 @@ namespace SMT
             IntelData idtwo = new IntelData("[00:00] blah.... > blah", "System");
             idtwo.IntelString = "Intel Filters : " + String.Join(",", EVEManager.IntelFilters);
 
+            IntelData idthree = new IntelData("[00:00] blah... > blah", "System");
+            idthree.IntelString = "Intel Alert Filters : " + String.Join(", ", EVEManager.IntelAlertFilters);
+
+            IntelData idfour = new IntelData("[00:00] blah... > blah", "System");
+            idfour.IntelString = "Intel Alert Filters Count: " + EVEManager.IntelAlertFilters.Count();
+
             IntelCache.Add(id);
             IntelCache.Add(idtwo);
+            IntelCache.Add(idthree);
+            IntelCache.Add(idfour);
 
             MapConf.CurrentEveLogFolderLocation = EVEManager.EVELogFolder;
 
@@ -1163,7 +1173,7 @@ namespace SMT
                 return;
             }
 
-            if (MapConf.PlayIntelSound || MapConf.FlashWindow)
+            if (MapConf.PlayIntelSound || MapConf.FlashWindow || MapConf.PlayIntelSoundOnPlayer)
             {
                 if (MapConf.PlaySoundOnlyInDangerZone || MapConf.FlashWindowOnlyInDangerZone)
                 {
@@ -1189,6 +1199,18 @@ namespace SMT
                                     }
                                 }
                             }
+                        }
+                    }
+                }
+                if (MapConf.PlayIntelSoundOnPlayer)
+                {
+                    // Check if the intel contains a player we should alert on
+                    foreach (string alertName in EVEManager.IntelAlertFilters)
+                    {
+                        if (id.RawIntelString.Contains(alertName))
+                        {
+                            playSound = playSound || MapConf.PlayIntelSoundOnPlayer;
+                            break;
                         }
                     }
                 }

--- a/SMT/MainWindow.xaml.cs
+++ b/SMT/MainWindow.xaml.cs
@@ -40,8 +40,6 @@ namespace SMT
 
         private List<InfoItem> InfoLayer;
 
-        private List<string> playerAlertNames;
-
         private Dictionary<string, long> CharacterNameIDCache;
         private Dictionary<long, string> CharacterIDNameCache;
 

--- a/SMT/MapConfig.cs
+++ b/SMT/MapConfig.cs
@@ -468,6 +468,10 @@ namespace SMT
         }
 
         [Category("Intel")]
+        [DisplayName("Warning on Player")]
+        public bool PlayIntelSoundOnPlayer { get; set; }
+
+        [Category("Intel")]
         [DisplayName("Warning On Unknown")]
         public bool PlayIntelSoundOnUnknown { get; set; }
 

--- a/SMT/Preferences.xaml
+++ b/SMT/Preferences.xaml
@@ -152,6 +152,7 @@
                                 <StackPanel>
 
                                     <CheckBox IsChecked="{Binding Path=PlayIntelSound}" Margin="0,2">Warning Sound</CheckBox>
+                                    <CheckBox IsChecked="{Binding Path=PlayIntelSoundOnPlayer}" Margin="0,2">Warning Sound on Player</CheckBox>
                                     <CheckBox IsChecked="{Binding Path=FlashWindow}" Margin="0,2" Content="Flash Window" />
                                     <StackPanel Orientation="Vertical" Margin="0,2">
                                         <Label Content="Warning Sound Volume" />

--- a/SMT/Preferences.xaml
+++ b/SMT/Preferences.xaml
@@ -15,7 +15,7 @@
 
     <Grid Background="{DynamicResource ButtonBorder}" Height="Auto" Width="Auto" HorizontalAlignment="Left" VerticalAlignment="Top">
         <DockPanel HorizontalAlignment="Stretch"  VerticalAlignment="Stretch">
-            <TabControl x:Name="tabControl" DockPanel.Dock="Top">
+            <TabControl x:Name="tabControl" DockPanel.Dock="Top" Height="487">
                 <TabItem Header="General">
                     <Grid>
                         <Grid.ColumnDefinitions>
@@ -194,7 +194,7 @@
                         </StackPanel>
 
                         <StackPanel Grid.Column="1">
-                            <GroupBox Margin="4" Height="auto">
+                            <GroupBox Margin="4" Height="453">
 
                                 <StackPanel Orientation="Vertical">
                                     <Label>Channel Filters</Label>
@@ -203,6 +203,8 @@
                                     <TextBox Width="271"  Height="80" Text="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Window}, Path=EM.IntelClearFilters, Converter={StaticResource stringJoiner}, Mode=TwoWay}"  TextWrapping="Wrap" AcceptsReturn="True" />
                                     <Label>Ignore Filters</Label>
                                     <TextBox Width="271"  Height="80" Text="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Window}, Path=EM.IntelIgnoreFilters, Converter={StaticResource stringJoiner}, Mode=TwoWay}"  TextWrapping="Wrap" AcceptsReturn="True" />
+                                    <Label Content="Alert Filters"/>
+                                    <TextBox Width="271"  Height="80" Text="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Window}, Path=EM.IntelAlertFilters, Converter={StaticResource stringJoiner}, Mode=TwoWay}"  TextWrapping="Wrap" AcceptsReturn="True" />
                                 </StackPanel>
                             </GroupBox>
                         </StackPanel>


### PR DESCRIPTION
## Features
- This will allow you to enter player names into a text file, and when that player appear in an intel channel, a sound will be heard
- When SMT starts, it will list the current player names it's checking for, along with a total count of names it's checking for
- The sound can be enabled or disabled via File->Preferences->Intel->"Warning Sound on Player"

## How-To
1) Open `IntelAlertFilters.txt` and enter the players you want alerted to, each on their own line
2) Start SMT, enable the settings, and prosper

## Limitations
- The sound is the already current warning sound
