### PR TITLE
Zarzakh bugfix, Multi Window option, Multi Character Display

### DIFF
--- a/SMT/MainWindow.xaml.cs
+++ b/SMT/MainWindow.xaml.cs
@@ -30,7 +30,7 @@ namespace SMT
     {
         public static MainWindow AppWindow;
         private LogonWindow logonBrowserWindow;
-        private Overlay overlayWindow;
+        private List<Overlay> overlayWindows;
 
         private MediaPlayer mediaPlayer;
         private PreferencesWindow preferencesWindow;
@@ -2475,19 +2475,32 @@ namespace SMT
 
         private void OverlayWindow_MenuItem_Click(object sender, RoutedEventArgs e)
         {
-            if (overlayWindow != null)
+            if (overlayWindows == null) overlayWindows = new List<Overlay>();
+
+            if (MapConf.OverlayIndividualCharacterWindows)
             {
-                return;
+                if (activeCharacter == null || overlayWindows.Any(w => w.OverlayCharacter == activeCharacter))
+                {
+                    return;
+                }  
+            }
+            else
+            {
+                if (overlayWindows.Count > 0)
+                {
+                    return;
+                }
             }
 
-            overlayWindow = new Overlay(this);
-            overlayWindow.Closing += OnOverlayWindowClosing;
-            overlayWindow.Show();
+            Overlay newOverlayWindow = new Overlay(this);
+            newOverlayWindow.Closing += OnOverlayWindowClosing;
+            newOverlayWindow.Show();
+            overlayWindows.Add(newOverlayWindow);
         }
 
         public void OnOverlayWindowClosing(object sender, CancelEventArgs e)
         {
-            overlayWindow = null;
+            overlayWindows.Remove((Overlay)sender);
         }
     }
 

--- a/SMT/MapConfig.cs
+++ b/SMT/MapConfig.cs
@@ -110,6 +110,8 @@ namespace SMT
         private bool m_overlayShowRoute = true;
         private bool m_overlayShowJumpBridges = true;
         private bool m_overlayShowSystemNames = false;
+        private bool m_overlayShowAllCharacterNames = false;
+        private bool m_overlayIndividualCharacterWindows = false;
 
         public MapConfig()
         {
@@ -1166,6 +1168,22 @@ namespace SMT
                 OnPropertyChanged("OverlayShowJumpBridges");
             }
         }
+        
+        [Category("Overlay")]
+        [DisplayName("Overlay Individual Character Windows")]
+        public bool OverlayIndividualCharacterWindows
+        {
+            get
+            {
+                return m_overlayIndividualCharacterWindows;
+            }
+            set
+            {
+                m_overlayIndividualCharacterWindows = value;
+
+                OnPropertyChanged("OverlayIndividualCharacterWindows");
+            }
+        }
 
         [Category("Overlay")]
         [DisplayName("Overlay Show System Names")]
@@ -1180,6 +1198,22 @@ namespace SMT
                 m_overlayShowSystemNames = value;
 
                 OnPropertyChanged("OverlayShowSystemNames");
+            }
+        }
+        
+        [Category("Overlay")]
+        [DisplayName("Overlay Show All Character Names")]
+        public bool OverlayShowAllCharacterNames
+        {
+            get
+            {
+                return m_overlayShowAllCharacterNames;
+            }
+            set
+            {
+                m_overlayShowAllCharacterNames = value;
+
+                OnPropertyChanged("OverlayShowAllCharacterNames");
             }
         }
 
@@ -1360,6 +1394,7 @@ namespace SMT
             OverlayShowRoute = true;
             OverlayShowJumpBridges = true;
             OverlayShowSystemNames = false;
+            OverlayShowAllCharacterNames = false;
 
             IntelFreshTime = 30;
             IntelStaleTime = 120;

--- a/SMT/Overlay.xaml
+++ b/SMT/Overlay.xaml
@@ -11,7 +11,11 @@
         Visibility="Visible"
         MinWidth="100"
         MinHeight="100"
-        Title="Overlay" Height="600" Width="600" AllowsTransparency="True">
+        Title="Overlay" 
+        Height="600" 
+        Width="600" 
+        AllowsTransparency="True"
+        >
     <Window.Background>
         <SolidColorBrush Opacity="0.2" Color="Black"></SolidColorBrush>
     </Window.Background>

--- a/SMT/Preferences.xaml
+++ b/SMT/Preferences.xaml
@@ -307,6 +307,7 @@
                                         <xctk:IntegerUpDown Value="{Binding Path=IntelHistoricTime}" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="0" Width="70" Minimum="5" Maximum="1200" Background="Transparent"  Foreground="White" ValueChanged="zkilltime_ValueChanged" />
                                         <Label Content="Finally, Intel is historic for x seconds" />
                                     </StackPanel>
+                                    <CheckBox Margin="0,3" IsChecked="{Binding Path=OverlayIndividualCharacterWindows}" Content="Open individual windows for each character." />
                                 </StackPanel>
                             </GroupBox>
                         </StackPanel>
@@ -325,6 +326,7 @@
                                         <CheckBox Margin="0,3" IsChecked="{Binding Path=OverlayShowNPCKillDelta}" Content="Show NPC kill delta" />
                                         <CheckBox Margin="0,3" IsChecked="{Binding Path=OverlayShowRoute}" Content="Show the current route" />
                                         <CheckBox Margin="0,3" IsChecked="{Binding Path=OverlayHunterModeShowFullRegion}" Content="Show the full region in hunter mode" />
+                                        <CheckBox Margin="0,3" IsChecked="{Binding Path=OverlayShowAllCharacterNames}" Content="Show the names of all characters on the map" />
                                     </StackPanel>
                                 </StackPanel>
                             </GroupBox>


### PR DESCRIPTION
There was a critical error when the overlay was open while a player was in Zarzakh. This was fixed and Zarzakh is no displayed correctly.

The overlay now shows all characters on the map that are available to SMT.

By selecting "Open individual windows for each character" changing the character name no longer switches an open overlay to that character. Instead, when "Overlay" is selected from the "File" menu, a separate window is opened for the selected character. Window sizes and positions are now saved on a per-character base.