### PR TITLE
Fix the auto follow failure, add http proxy with esi request.

### DIFF
--- a/SMT/MainWindow.xaml.cs
+++ b/SMT/MainWindow.xaml.cs
@@ -138,6 +138,10 @@ namespace SMT
             EVEData.EveManager.Instance = EVEManager;
             EVEManager.EVELogFolder = MapConf.CustomEveLogFolderLocation;
 
+            EVEManager.EnableHTTPProxy = MapConf.EnableHTTPProxy;
+            EVEManager.HTTPProxyServer = MapConf.HTTPProxyServer;
+            EVEManager.HTTPProxyPort = MapConf.HTTPProxyPort;
+
             EVEManager.UseESIForCharacterPositions = MapConf.UseESIForCharacterPositions;
 
             // if we want to re-build the data as we've changed the format, recreate it all from scratch

--- a/SMT/MapConfig.cs
+++ b/SMT/MapConfig.cs
@@ -109,6 +109,11 @@ namespace SMT
         private bool m_overlayShowAllCharacterNames = false;
         private bool m_overlayIndividualCharacterWindows = false;
 
+        private bool m_EnableHTTPProxy;
+        private string m_HTTPProxyServer;
+        private string m_HTTPProxyPort;
+
+
         public MapConfig()
         {
             SetDefaults();
@@ -219,6 +224,22 @@ namespace SMT
 
         [Browsable(false)]
         public bool Debug_EnableMapEdit { get; set; }
+
+
+        [Browsable(false)]
+        public bool EnableHTTPProxy
+        {
+            get => m_EnableHTTPProxy;
+            set
+            {
+                m_EnableHTTPProxy = value;
+                OnPropertyChanged("EnableHTTPProxy");
+            }
+        }
+
+        public string HTTPProxyServer { get; set; }
+        public string HTTPProxyPort { get; set; }
+
 
         public bool DisableJumpBridgesPathAnimation
         {

--- a/SMT/Preferences.xaml
+++ b/SMT/Preferences.xaml
@@ -349,14 +349,28 @@
                 <TabItem Header="Debug">
                     <Grid>
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="50*" />
-                            <ColumnDefinition Width="50*" />
+                            <ColumnDefinition Width="100*" />
+                            <ColumnDefinition Width="202*"/>
+                            <ColumnDefinition Width="303*" />
                         </Grid.ColumnDefinitions>
 
-                        <StackPanel Grid.Column="0">
+                        <StackPanel Grid.Column="0" Grid.ColumnSpan="3" Margin="0,0,302,0">
                             <GroupBox Header="General" Margin="4" Height="auto">
                                 <StackPanel>
                                     <CheckBox IsChecked="{Binding Path=Debug_EnableMapEdit}" Margin="0,2">Enable Universe Map Edits</CheckBox>
+                                </StackPanel>
+                            </GroupBox>
+                            <GroupBox Header="Network" Margin="4,4,4,4">
+                                <StackPanel>
+                                    <CheckBox IsChecked="{Binding Path=EnableHTTPProxy}" Margin="0,2" Content="Enable HTTP Proxy?"/>
+                                    <StackPanel Orientation="Horizontal">
+                                        <Label Content="Server" Width="50"/>
+                                        <TextBox TextWrapping="Wrap"  Text="{Binding Path=HTTPProxyServer}" Width="120" Height="20" />
+                                    </StackPanel>
+                                    <StackPanel Orientation="Horizontal">
+                                        <Label Content="Port" Width="50"/>
+                                        <TextBox TextWrapping="Wrap"  Text="{Binding Path=HTTPProxyPort}" Width="120" Height="20" />
+                                    </StackPanel>
                                 </StackPanel>
                             </GroupBox>
                         </StackPanel>


### PR DESCRIPTION
Has 2 code changes:

1. When I used the Simplified Chinese game client, the "**Auto Follow Active Character**" function failed. I checked the source code and found that the problem was caused by language localization (similar issues should also exist under other non English prophecies).
﻿

> 
> -  Local channel file name differences (Documents \ EVE \ logs \ Chatlogs \)
> 
> ```Local_20240626:090010_2114061886.txt```
> 
> - Differences in file content: (When the client uses Simplified Chinese)
> 
> ﻿
> ```
> ---------------------------------------------------------------
> ﻿
> Channel ID:      local
> Channel Name:     local
> Listener:        Bink Wang
> Session started: 2024.06.26 09:00:10
> ---------------------------------------------------------------
> ﻿
> [2024.06.26 09:00:13] EVE system>Channel change to local: U-QVWD*
> [2024.06.26 09:01:36] EVE system>Channel change to local: 36N-HZ*
> ﻿[ 2024.06.26 09:05:19 ] Bink Wang > test
> [June 26, 2024 09:07:20] EVE system>Channel change to local: U-QVWD*
> [June 26, 2024 09:08:14] EVE system>Channel change to local: 36N-HZ*
> [June 26, 2024 09:09:15] EVE system>Channel change to local: U-QVWD*
> ```

2. Chinese players failed to add characters due to GWF, which prevented ESI from accessing the interface correctly; I have added a feature to enable HTTP proxy on the Preferences>Debug tab to address this issue.

I have made modifications to the relevant code, and the repaired version works properly on my client.