### PR TITLE
Added options how to display char names on overlay.

### DIFF
--- a/SMT/MapConfig.cs
+++ b/SMT/MapConfig.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Windows.Controls;
 using System.Windows.Media;
 using System.Xml.Serialization;
 
@@ -108,6 +109,7 @@ namespace SMT
         private bool m_overlayShowSystemNames = false;
         private bool m_overlayShowAllCharacterNames = false;
         private bool m_overlayIndividualCharacterWindows = false;
+        private string m_overlayAdditionalCharacterNamesDisplay = "All";
 
         public MapConfig()
         {
@@ -1133,6 +1135,22 @@ namespace SMT
                 OnPropertyChanged("OverlayIndividualCharacterWindows");
             }
         }
+        
+        [Category("Overlay")]
+        [DisplayName("Overlay Additional Character Names Display")]
+        public string OverlayAdditionalCharacterNamesDisplay
+        {
+            get
+            {
+                return m_overlayAdditionalCharacterNamesDisplay;
+            }
+            set
+            {
+                m_overlayAdditionalCharacterNamesDisplay = value;
+
+                OnPropertyChanged("OverlayAdditionalCharacterNamesDisplay");
+            }
+        }
 
         [Category("Overlay")]
         [DisplayName("Overlay Show System Names")]
@@ -1342,6 +1360,7 @@ namespace SMT
             OverlayShowJumpBridges = true;
             OverlayShowSystemNames = false;
             OverlayShowAllCharacterNames = false;
+            OverlayAdditionalCharacterNamesDisplay = "All";
 
             IntelFreshTime = 30;
             IntelStaleTime = 120;

--- a/SMT/Preferences.xaml
+++ b/SMT/Preferences.xaml
@@ -304,6 +304,15 @@
                                         <Label Content="Finally, Intel is historic for x seconds" />
                                     </StackPanel>
                                     <CheckBox Margin="0,3" IsChecked="{Binding Path=OverlayIndividualCharacterWindows}" Content="Open individual windows for each character." />
+                                    <StackPanel Orientation="Horizontal" Margin="0,2">
+                                        <Label Content="Char names on overlay: " />
+                                        <ComboBox SelectedValuePath="Content" SelectedValue="{Binding Path=OverlayAdditionalCharacterNamesDisplay}" Width="150">
+                                            <ComboBoxItem Content="All"></ComboBoxItem>
+                                            <ComboBoxItem Content="Overlay Character"></ComboBoxItem>
+                                            <ComboBoxItem Content="None"></ComboBoxItem>
+                                            <ComboBoxItem Content="Number"></ComboBoxItem>
+                                        </ComboBox>
+                                    </StackPanel>
                                 </StackPanel>
                             </GroupBox>
                         </StackPanel>


### PR DESCRIPTION
In the preferences players can now choose between

- Displaying all char names below the system they are in
- Displaying only the name of the char for which the overlay is openend / the char selected in the main window
- Displaying no names at all
- Displaying a number how many chars are in that system