### PR TITLE
Moved hotkey handling to main window and fixed a possible crash. 

### DIFF
--- a/SMT/MainWindow.xaml.cs
+++ b/SMT/MainWindow.xaml.cs
@@ -19,6 +19,8 @@ using System.Xml;
 using System.Xml.Serialization;
 using Microsoft.Toolkit.Uwp.Notifications;
 using Microsoft.Win32;
+using NHotkey;
+using NHotkey.Wpf;
 using SMT.EVEData;
 
 namespace SMT
@@ -2509,6 +2511,15 @@ namespace SMT
                     return;
                 }
             }
+            
+            // Set up hotkeys
+            try
+            {
+                HotkeyManager.Current.AddOrReplace("Toggle click trough overlay windows.", Key.T, ModifierKeys.Alt | ModifierKeys.Control | ModifierKeys.Shift, OverlayWindows_ToggleClicktrough_HotkeyTrigger);
+            }
+            catch (NHotkey.HotkeyAlreadyRegisteredException exception)
+            {
+            }
 
             Overlay newOverlayWindow = new Overlay(this);
             newOverlayWindow.Closing += OnOverlayWindowClosing;
@@ -2517,6 +2528,11 @@ namespace SMT
         }
 
         private void OverlayClickTroughToggle_MenuItem_Click(object sender, RoutedEventArgs e)
+        {
+            OverlayWindow_ToggleClickTrough();
+        }
+        
+        private void OverlayWindows_ToggleClicktrough_HotkeyTrigger(object sender, HotkeyEventArgs eventArgs)
         {
             OverlayWindow_ToggleClickTrough();
         }
@@ -2533,6 +2549,17 @@ namespace SMT
         public void OnOverlayWindowClosing(object sender, CancelEventArgs e)
         {
             overlayWindows.Remove((Overlay)sender);
+
+            if (overlayWindows.Count < 1)
+            {
+                try
+                {
+                    HotkeyManager.Current.Remove("Toggle click trough overlay windows.");
+                }
+                catch
+                {
+                }
+            }
         }
     }
 

--- a/SMT/Overlay.xaml.cs
+++ b/SMT/Overlay.xaml.cs
@@ -1,5 +1,4 @@
-﻿using NHotkey.Wpf;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -19,7 +18,6 @@ using System.Windows.Threading;
 using Windows.Services;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.VisualBasic.Logging;
-using NHotkey;
 using SMT.EVEData;
 using static SMT.EVEData.Navigation;
 
@@ -407,9 +405,6 @@ namespace SMT
             Closing += Overlay_Closing;
             // We can only redraw stuff when the canvas is actually resized, otherwise dimensions will be wrong!
             overlay_Canvas.SizeChanged += OnCanvasSizeChanged;
-            
-            // Set up hotkeys
-            HotkeyManager.Current.AddOrReplace("Toggle click trough overlay windows.", Key.T, ModifierKeys.Alt | ModifierKeys.Control | ModifierKeys.Shift, OnClickTroughToggle);
 
             // Update settings
             intelUrgentPeriod = mainWindow.MapConf.IntelFreshTime;
@@ -448,11 +443,6 @@ namespace SMT
             
             locationUpdateTimer.Start();
             dataUpdateTimer.Start();
-        }
-
-        private void OnClickTroughToggle(object sender, HotkeyEventArgs e)
-        {
-            mainWindow.OverlayWindow_ToggleClickTrough();
         }
 
         public void ToggleClickTrough(bool isClickTrough)


### PR DESCRIPTION
Wrapped the hotkey setting in a try catch to prevent a crash when another hotkey is registered with the same key combination.
Added proper hotkey removal when last overlay is closed.