### PR TITLE
Removed deprecated preference, cleared up wording of preferences for overlay

### DIFF
--- a/SMT/MapConfig.cs
+++ b/SMT/MapConfig.cs
@@ -107,7 +107,6 @@ namespace SMT
         private bool m_overlayShowRoute = true;
         private bool m_overlayShowJumpBridges = true;
         private bool m_overlayShowSystemNames = false;
-        private bool m_overlayShowAllCharacterNames = false;
         private bool m_overlayIndividualCharacterWindows = false;
         private string m_overlayAdditionalCharacterNamesDisplay = "All";
 
@@ -1174,22 +1173,6 @@ namespace SMT
         }
 
         [Category("Overlay")]
-        [DisplayName("Overlay Show All Character Names")]
-        public bool OverlayShowAllCharacterNames
-        {
-            get
-            {
-                return m_overlayShowAllCharacterNames;
-            }
-            set
-            {
-                m_overlayShowAllCharacterNames = value;
-
-                OnPropertyChanged("OverlayShowAllCharacterNames");
-            }
-        }
-
-        [Category("Overlay")]
         [DisplayName("Overlay Intel Fresh Time")]
         public float IntelFreshTime
         {
@@ -1368,7 +1351,6 @@ namespace SMT
             OverlayShowRoute = true;
             OverlayShowJumpBridges = true;
             OverlayShowSystemNames = false;
-            OverlayShowAllCharacterNames = false;
             OverlayAdditionalCharacterNamesDisplay = "All";
 
             IntelFreshTime = 30;

--- a/SMT/Overlay.xaml.cs
+++ b/SMT/Overlay.xaml.cs
@@ -292,7 +292,6 @@ namespace SMT
         private bool showCharLocation = true;
         private bool showJumpBridges = true;
         private bool showSystemNames = false;
-        private bool showAllCharacterNames = false;
         private bool individualCharacterWindows = false;
         private string additionalCharacterNamesDisplay = "All";
 
@@ -409,7 +408,6 @@ namespace SMT
             overlayDepth = mainWindow.MapConf.OverlayRange + 1;
             showJumpBridges = mainWindow.MapConf.OverlayShowJumpBridges;
             showSystemNames = mainWindow.MapConf.OverlayShowSystemNames;
-            showAllCharacterNames = mainWindow.MapConf.OverlayShowAllCharacterNames;
             individualCharacterWindows = mainWindow.MapConf.OverlayIndividualCharacterWindows;
             additionalCharacterNamesDisplay = mainWindow.MapConf.OverlayAdditionalCharacterNamesDisplay;
 
@@ -1911,13 +1909,6 @@ namespace SMT
             if(e.PropertyName == "OverlayShowSystemNames")
             {
                 showSystemNames = mainWindow.MapConf.OverlayShowSystemNames;
-                ClearView();
-                RefreshCurrentView();
-            }
-
-            if(e.PropertyName == "OverlayShowAllCharacterNames")
-            {
-                showAllCharacterNames = mainWindow.MapConf.OverlayShowAllCharacterNames;
                 ClearView();
                 RefreshCurrentView();
             }

--- a/SMT/Preferences.xaml
+++ b/SMT/Preferences.xaml
@@ -399,16 +399,15 @@
 
                                         <StackPanel Orientation="Vertical" Margin="0,0">
                                             <Label Content="Overlay Information" />
-                                            <CheckBox Margin="0,3" IsChecked="{Binding Path=OverlayShowCharName}" Content="Show name of the active character" />
-                                            <CheckBox Margin="0,3" IsChecked="{Binding Path=OverlayShowCharLocation}" Content="Show location of the active character" />
-                                            <CheckBox Margin="0,3" IsChecked="{Binding Path=OverlayShowJumpBridges}" Content="Show JumpBridges" />
-                                            <CheckBox Margin="0,3" IsChecked="{Binding Path=OverlayShowSystemNames}" Content="Show Individual System Names" />
+                                            <CheckBox Margin="0,3" IsChecked="{Binding Path=OverlayShowCharName}" Content="Show name of the active character in title" />
+                                            <CheckBox Margin="0,3" IsChecked="{Binding Path=OverlayShowCharLocation}" Content="Show location of the active character in title" />
+                                            <CheckBox Margin="0,3" IsChecked="{Binding Path=OverlayShowJumpBridges}" Content="Show JumpBridges on overlay" />
+                                            <CheckBox Margin="0,3" IsChecked="{Binding Path=OverlayShowSystemNames}" Content="Show Individual System Names on overlay" />
                                             <Label Content="Hunter Mode Information" />
                                             <CheckBox Margin="0,3" IsChecked="{Binding Path=OverlayShowNPCKills}" Content="Show NPC kills" />
                                             <CheckBox Margin="0,3" IsChecked="{Binding Path=OverlayShowNPCKillDelta}" Content="Show NPC kill delta" />
                                             <CheckBox Margin="0,3" IsChecked="{Binding Path=OverlayShowRoute}" Content="Show the current route" />
                                             <CheckBox Margin="0,3" IsChecked="{Binding Path=OverlayHunterModeShowFullRegion}" Content="Show the full region in hunter mode" />
-                                            <CheckBox Margin="0,3" IsChecked="{Binding Path=OverlayShowAllCharacterNames}" Content="Show the names of all characters on the map" />
                                         </StackPanel>
                                     </StackPanel>
                                 </GroupBox>


### PR DESCRIPTION
Removed OverlayShowAllCharacterNames from Preferences and all code. Was deprecated by dropdown to configure which chars to show on the overlay. 

Also cleared up the wording for the preferences that handle if the name of the character or the system is shown in the title of the overlay window.