### PR TITLE
Add ZKB float window, Chinese ship type names, and language persistence

### DIFF
--- a/EVEData/EveManager.cs
+++ b/EVEData/EveManager.cs
@@ -676,6 +676,11 @@ namespace SMT.EVEData
         public SerializableDictionary<string, string> ShipTypes { get; set; }
 
         /// <summary>
+        /// Gets or sets the Chinese Ship Type ID to Name dictionary (populated from ESI)
+        /// </summary>
+        public SerializableDictionary<string, string> ShipTypesCN { get; set; } = new SerializableDictionary<string, string>();
+
+        /// <summary>
         /// Gets or sets the System ID to Name dictionary
         /// </summary>
         public SerializableDictionary<long, string> SystemIDToName { get; set; }
@@ -2394,6 +2399,76 @@ namespace SMT.EVEData
                         }
                     }
                 }
+            }
+            catch { }
+        }
+
+        /// <summary>
+        /// Load Chinese ship type names from local cache
+        /// </summary>
+        public void LoadShipTypesCNFromCache()
+        {
+            string cnFile = Path.Combine(SaveDataRootFolder, "ShipTypesCN.dat");
+            if (File.Exists(cnFile))
+            {
+                try
+                {
+                    ShipTypesCN = Serialization.DeserializeFromDisk<SerializableDictionary<string, string>>(cnFile) ?? new SerializableDictionary<string, string>();
+                }
+                catch { ShipTypesCN = new SerializableDictionary<string, string>(); }
+            }
+        }
+
+        /// <summary>
+        /// Fetch missing Chinese ship type names from ESI
+        /// </summary>
+        public async Task FetchShipTypeChineseNamesAsync(CancellationToken cancellationToken = default)
+        {
+            if (ShipTypes == null || ShipTypesCN == null) return;
+
+            List<int> missingIDs = new List<int>();
+            foreach (var kvp in ShipTypes)
+            {
+                if (!ShipTypesCN.ContainsKey(kvp.Key) && int.TryParse(kvp.Key, out int typeId) && typeId > 0)
+                {
+                    missingIDs.Add(typeId);
+                }
+            }
+
+            if (missingIDs.Count == 0) return;
+
+            try
+            {
+                using (var semaphore = new SemaphoreSlim(5))
+                {
+                    var tasks = missingIDs.Select(async typeId =>
+                    {
+                        await semaphore.WaitAsync(cancellationToken);
+                        try
+                        {
+                            var response = await EveApiClient.Universe.GetTypeInfoAsync(typeId, null, "zh");
+                            if (response != null && response.Model != null && !string.IsNullOrEmpty(response.Model.Name))
+                            {
+                                lock (ShipTypesCN)
+                                {
+                                    ShipTypesCN[typeId.ToString()] = response.Model.Name;
+                                }
+                            }
+                        }
+                        catch { }
+                        finally { semaphore.Release(); }
+                    });
+
+                    await Task.WhenAll(tasks);
+                }
+            }
+            catch { }
+
+            // Save cache
+            try
+            {
+                string cnFile = Path.Combine(SaveDataRootFolder, "ShipTypesCN.dat");
+                Serialization.SerializeToDisk(ShipTypesCN, cnFile);
             }
             catch { }
         }

--- a/EVEData/ZKillRedisQ.cs
+++ b/EVEData/ZKillRedisQ.cs
@@ -132,7 +132,8 @@ namespace SMT.EVEData
                         zs.SystemName = EveManager.Instance.GetEveSystemNameFromID((int)r2z2Data.Esi.SolarSystemId);
                         zs.KillTime = r2z2Data.Esi.KillmailTime.ToLocalTime();
 
-                        string shipID = r2z2Data.Esi.Victim.ShipTypeId.ToString();
+                        zs.ShipTypeID = r2z2Data.Esi.Victim.ShipTypeId;
+                        string shipID = zs.ShipTypeID.ToString();
                         if(EveManager.Instance.ShipTypes.ContainsKey(shipID))
                         {
                             zs.ShipType = EveManager.Instance.ShipTypes[shipID];
@@ -231,9 +232,51 @@ namespace SMT.EVEData
             public DateTimeOffset KillTime { get; set; }
 
             /// <summary>
-            /// Gets or sets the Ship Lost in this kill
+            /// Gets or sets the Ship Type ID from the kill mail
             /// </summary>
-            public string ShipType { get; set; }
+            public int ShipTypeID { get; set; }
+
+            private string m_shipType;
+
+            /// <summary>
+            /// Gets or sets the Ship Lost in this kill (English name)
+            /// </summary>
+            public string ShipType
+            {
+                get => m_shipType;
+                set
+                {
+                    m_shipType = value;
+                    OnPropertyChanged("ShipType");
+                    OnPropertyChanged("ShipTypeDisplay");
+                }
+            }
+
+            /// <summary>
+            /// Gets the ship type name in the current display language
+            /// </summary>
+            public string ShipTypeDisplay
+            {
+                get
+                {
+                    if (EveManager.CurrentLanguage == "zh-CN" &&
+                        EveManager.Instance != null &&
+                        EveManager.Instance.ShipTypesCN != null &&
+                        EveManager.Instance.ShipTypesCN.ContainsKey(ShipTypeID.ToString()))
+                    {
+                        return EveManager.Instance.ShipTypesCN[ShipTypeID.ToString()];
+                    }
+                    return ShipType;
+                }
+            }
+
+            /// <summary>
+            /// Notify that ShipTypeDisplay may have changed (e.g. after language change or CN names loaded)
+            /// </summary>
+            public void RefreshShipTypeDisplay()
+            {
+                OnPropertyChanged("ShipTypeDisplay");
+            }
 
             /// <summary>
             /// Gets or sets the System ID the kill was in

--- a/SMT/App.xaml.cs
+++ b/SMT/App.xaml.cs
@@ -1,10 +1,7 @@
-﻿using System.Windows;
+using System.Windows;
 
 namespace SMT
 {
-    /// <summary>
-    /// Interaction logic for App.xaml
-    /// </summary>
     public partial class App : Application
     {
     }

--- a/SMT/Languages/en-US.xaml
+++ b/SMT/Languages/en-US.xaml
@@ -110,10 +110,18 @@
     <s:String x:Key="Prefs_Ovl_NPCDel">Show NPC kill delta</s:String>
     <s:String x:Key="Prefs_Ovl_Route">Show the current route</s:String>
     <s:String x:Key="Prefs_Ovl_FullReg">Show the full region in hunter mode</s:String>
+
+    <s:String x:Key="Prefs_ZKB_FloatGrp">ZKB Float Window</s:String>
+    <s:String x:Key="Prefs_ZKB_FloatBgOp">Background Opacity</s:String>
+    <s:String x:Key="Prefs_ZKB_FloatCtOp">Content Opacity</s:String>
+    <s:String x:Key="Prefs_ZKB_FloatMax">Max Kills to Display</s:String>
+    <s:String x:Key="Prefs_ZKB_FloatReg">Filter by Selected Region</s:String>
+
     <s:String x:Key="Prefs_Col_Reset">Reset Colours</s:String>
 
     <s:String x:Key="Main_Menu_Characters">Characters</s:String>
     <s:String x:Key="Main_Menu_Overlay">Overlay</s:String>
+    <s:String x:Key="Main_Menu_ZKBFloat">ZKB Float Window</s:String>
     <s:String x:Key="Main_Menu_Exit">Exit</s:String>
     <s:String x:Key="Main_Menu_Data">Data</s:String>
     <s:String x:Key="Main_Menu_ManageInfra">Manage Infrastructure Upgrades...</s:String>

--- a/SMT/Languages/zh-CN.xaml
+++ b/SMT/Languages/zh-CN.xaml
@@ -110,10 +110,18 @@
     <s:String x:Key="Prefs_Ovl_NPCDel">显示 NPC 击杀数量的变化差值</s:String>
     <s:String x:Key="Prefs_Ovl_Route">在悬浮窗上画出设定的自动导航路线</s:String>
     <s:String x:Key="Prefs_Ovl_FullReg">猎手模式下强制显示整个星域地图</s:String>
+
+    <s:String x:Key="Prefs_ZKB_FloatGrp">ZKB 浮动窗口设置</s:String>
+    <s:String x:Key="Prefs_ZKB_FloatBgOp">背景不透明度</s:String>
+    <s:String x:Key="Prefs_ZKB_FloatCtOp">内容不透明度</s:String>
+    <s:String x:Key="Prefs_ZKB_FloatMax">最大显示击杀数</s:String>
+    <s:String x:Key="Prefs_ZKB_FloatReg">仅显示当前星域</s:String>
+
     <s:String x:Key="Prefs_Col_Reset">重置所有颜色为默认</s:String>
 
     <s:String x:Key="Main_Menu_Characters">角色管理</s:String>
     <s:String x:Key="Main_Menu_Overlay">开启雷达悬浮窗</s:String>
+    <s:String x:Key="Main_Menu_ZKBFloat">ZKB 浮动窗口</s:String>
     <s:String x:Key="Main_Menu_Exit">退出程序</s:String>
     <s:String x:Key="Main_Menu_Data">数据工具</s:String>
     <s:String x:Key="Main_Menu_ManageInfra">管理基础设施升级...</s:String>

--- a/SMT/MainWindow.xaml
+++ b/SMT/MainWindow.xaml
@@ -54,6 +54,7 @@
                     <MenuItem Header="{DynamicResource Main_Menu_Characters}" Click="Characters_MenuItem_Click" />
                     <MenuItem Header="{DynamicResource Menu_Preferences}" Click="Preferences_MenuItem_Click" />
                     <MenuItem Header="{DynamicResource Main_Menu_Overlay}" Click="OverlayWindow_MenuItem_Click" />
+                    <MenuItem Header="{DynamicResource Main_Menu_ZKBFloat}" Click="ZKBFloatWindow_MenuItem_Click" />
                     <MenuItem Header="{DynamicResource Main_Menu_Exit}" Click="Exit_MenuItem_Click" />
                 </MenuItem>
 
@@ -578,7 +579,7 @@
                                                         </DataGridTextColumn.Header>
                                                     </DataGridTextColumn>
 
-                                                    <DataGridTextColumn Binding="{Binding ShipType}" Width="30*" IsReadOnly="True" CanUserReorder="False" CanUserSort="False">
+                                                    <DataGridTextColumn Binding="{Binding ShipTypeDisplay}" Width="30*" IsReadOnly="True" CanUserReorder="False" CanUserSort="False">
                                                         <DataGridTextColumn.Header>
                                                             <TextBlock Text="{DynamicResource ZKB_Column_ShipType}" />
                                                         </DataGridTextColumn.Header>

--- a/SMT/MainWindow.xaml.cs
+++ b/SMT/MainWindow.xaml.cs
@@ -35,6 +35,7 @@ namespace SMT
         public static MainWindow AppWindow;
         private LogonWindow logonBrowserWindow;
         private List<Overlay> overlayWindows = new();
+        private ZKBMonitor zkbMonitorWindow;
         private bool overlayWindowsAreClickTrough = false;
 
         public bool OverlayWindowsAreClickTrough
@@ -141,32 +142,7 @@ namespace SMT
             CharacterNameIDCache = new Dictionary<string, long>();
             CharacterIDNameCache = new Dictionary<long, string>();
 
-            InitializeComponent();
-
-            Title = $"SMT : {EveAppConfig.SMT_TITLE} ({EveAppConfig.SMT_VERSION})";
-
-            // Load the Dock Manager Layout file
-            string dockManagerLayoutName = Path.Combine(EveAppConfig.StorageRoot, "Layout_" + WindowLayoutVersion + ".dat");
-            if(File.Exists(dockManagerLayoutName) && OperatingSystem.IsWindows())
-            {
-                try
-                {
-                    AvalonDock.Layout.Serialization.XmlLayoutSerializer ls = new(dockManager);
-                    using(var sr = new StreamReader(dockManagerLayoutName))
-                    {
-                        ls.Deserialize(sr);
-                    }
-                }
-                catch
-                {
-                }
-            }
-
-            // Due to bugs in the Dock manager patch up the content id's for the 2 main views
-            RegionLayoutDoc = FindDocWithContentID(dockManager.Layout, "MapRegionContentID");
-            UniverseLayoutDoc = FindDocWithContentID(dockManager.Layout, "FullUniverseViewID");
-
-            // load any custom map settings off disk
+            // Load MapConfig BEFORE InitializeComponent so language can be applied
             string mapConfigFileName = Path.Combine(EveAppConfig.StorageRoot, "MapConfig_" + MapConfig.SaveVersion + ".dat");
 
             if(File.Exists(mapConfigFileName))
@@ -191,6 +167,55 @@ namespace SMT
                 MapConf = new MapConfig();
                 MapConf.SetDefaultColours();
             }
+
+            // Apply persisted language before InitializeComponent resolves DynamicResource
+            if (MapConf != null && MapConf.Language == "zh-CN")
+            {
+                ResourceDictionary oldLangDict = null;
+                foreach (var dict in Application.Current.Resources.MergedDictionaries)
+                {
+                    if (dict.Source != null && dict.Source.OriginalString.StartsWith("Languages/"))
+                    {
+                        oldLangDict = dict;
+                        break;
+                    }
+                }
+
+                ResourceDictionary newLangDict = new ResourceDictionary
+                {
+                    Source = new Uri("Languages/zh-CN.xaml", UriKind.Relative)
+                };
+                Application.Current.Resources.MergedDictionaries.Add(newLangDict);
+                if (oldLangDict != null)
+                    Application.Current.Resources.MergedDictionaries.Remove(oldLangDict);
+
+                EVEData.EveManager.CurrentLanguage = "zh-CN";
+            }
+
+            InitializeComponent();
+
+            Title = $"SMT : {EveAppConfig.SMT_TITLE} ({EveAppConfig.SMT_VERSION})";
+
+            // Load the Dock Manager Layout file
+            string dockManagerLayoutName = Path.Combine(EveAppConfig.StorageRoot, "Layout_" + WindowLayoutVersion + ".dat");
+            if(File.Exists(dockManagerLayoutName) && OperatingSystem.IsWindows())
+            {
+                try
+                {
+                    AvalonDock.Layout.Serialization.XmlLayoutSerializer ls = new(dockManager);
+                    using(var sr = new StreamReader(dockManagerLayoutName))
+                    {
+                        ls.Deserialize(sr);
+                    }
+                }
+                catch
+                {
+                }
+            }
+
+            // Due to bugs in the Dock manager patch up the content id's for the 2 main views
+            RegionLayoutDoc = FindDocWithContentID(dockManager.Layout, "MapRegionContentID");
+            UniverseLayoutDoc = FindDocWithContentID(dockManager.Layout, "FullUniverseViewID");
 
             if(MapConf.AlwaysOnTop)
             {
@@ -233,6 +258,18 @@ namespace SMT
             {
                 EVEManager.LoadFromDisk();
             }
+
+            EVEManager.LoadShipTypesCNFromCache();
+            _ = EVEManager.FetchShipTypeChineseNamesAsync().ContinueWith(_ =>
+            {
+                Application.Current?.Dispatcher.Invoke(() =>
+                {
+                    foreach (var item in EVEManager.ZKillFeed.KillStream)
+                    {
+                        item.RefreshShipTypeDisplay();
+                    }
+                });
+            });
 
             EVEManager.SetupIntelWatcher();
             EVEManager.SetupGameLogWatcher();
@@ -2526,6 +2563,20 @@ namespace SMT
             newOverlayWindow.Closing += OnOverlayWindowClosing;
             newOverlayWindow.Show();
             overlayWindows.Add(newOverlayWindow);
+        }
+
+        private void ZKBFloatWindow_MenuItem_Click(object sender, RoutedEventArgs e)
+        {
+            if (zkbMonitorWindow != null)
+            {
+                zkbMonitorWindow.Close();
+                zkbMonitorWindow = null;
+                return;
+            }
+
+            zkbMonitorWindow = new ZKBMonitor(this);
+            zkbMonitorWindow.Closing += (s, args) => { zkbMonitorWindow = null; };
+            zkbMonitorWindow.Show();
         }
 
         private void OverlayClickTroughToggle_MenuItem_Click(object sender, RoutedEventArgs e)

--- a/SMT/MapConfig.cs
+++ b/SMT/MapConfig.cs
@@ -12,6 +12,9 @@ namespace SMT
         [Browsable(false)]
         public MapColours ActiveColourScheme;
 
+        [Browsable(false)]
+        private string m_Language = "en-US";
+
         [Category("Navigation")]
         private bool m_AlwaysOnTop;
 
@@ -111,12 +114,32 @@ namespace SMT
         private bool m_overlayIndividualCharacterWindows = false;
         private string m_overlayAdditionalCharacterNamesDisplay = "All";
 
+        // ZKB float window settings
+        private float m_zkbFloatBackgroundOpacity = 0.2f;
+        private float m_zkbFloatContentOpacity = 0.85f;
+        private int m_zkbFloatMaxKills = 50;
+        private bool m_zkbFloatFilterByRegion = true;
+
         public MapConfig()
         {
             SetDefaults();
         }
 
         public event PropertyChangedEventHandler PropertyChanged;
+
+        [Browsable(false)]
+        public string Language
+        {
+            get { return m_Language; }
+            set
+            {
+                if (m_Language != value)
+                {
+                    m_Language = value;
+                    OnPropertyChanged("Language");
+                }
+            }
+        }
 
         [Category("General")]
         [DisplayName("Always on top")]
@@ -1218,6 +1241,38 @@ namespace SMT
                 OnPropertyChanged("IntelHistoricTime");
             }
         }
+
+        [Browsable(false)]
+        public float ZKBFloatBackgroundOpacity
+        {
+            get { return m_zkbFloatBackgroundOpacity; }
+            set { m_zkbFloatBackgroundOpacity = Math.Clamp(value, 0.05f, 1.0f); OnPropertyChanged("ZKBFloatBackgroundOpacity"); }
+        }
+
+        [Browsable(false)]
+        public float ZKBFloatContentOpacity
+        {
+            get { return m_zkbFloatContentOpacity; }
+            set { m_zkbFloatContentOpacity = Math.Clamp(value, 0.1f, 1.0f); OnPropertyChanged("ZKBFloatContentOpacity"); }
+        }
+
+        [Browsable(false)]
+        public int ZKBFloatMaxKills
+        {
+            get { return m_zkbFloatMaxKills; }
+            set { m_zkbFloatMaxKills = Math.Clamp(value, 10, 200); OnPropertyChanged("ZKBFloatMaxKills"); }
+        }
+
+        [Browsable(false)]
+        public bool ZKBFloatFilterByRegion
+        {
+            get { return m_zkbFloatFilterByRegion; }
+            set { m_zkbFloatFilterByRegion = value; OnPropertyChanged("ZKBFloatFilterByRegion"); }
+        }
+
+        [XmlIgnore]
+        [Browsable(false)]
+        public bool ZKBFloatWindowOpen { get; set; }
 
         public int ZkillExpireTimeMinutes
         {

--- a/SMT/Preferences.xaml
+++ b/SMT/Preferences.xaml
@@ -400,6 +400,33 @@
                                     </StackPanel>
                                 </GroupBox>
                             </Border>
+
+                            <Border BorderBrush="{DynamicResource ButtonBorder}" BorderThickness="1" Margin="2">
+                                <GroupBox Header="{DynamicResource Prefs_ZKB_FloatGrp}" Margin="4">
+                                    <StackPanel>
+                                        <StackPanel Orientation="Vertical" Margin="0,2">
+                                            <Label Content="{DynamicResource Prefs_ZKB_FloatBgOp}" />
+                                            <Slider Value="{Binding Path=ZKBFloatBackgroundOpacity}"
+                                                    Minimum="0.05" Maximum="1.0" TickFrequency="0.05"
+                                                    TickPlacement="BottomRight" IsMoveToPointEnabled="True" />
+                                        </StackPanel>
+                                        <StackPanel Orientation="Vertical" Margin="0,2">
+                                            <Label Content="{DynamicResource Prefs_ZKB_FloatCtOp}" />
+                                            <Slider Value="{Binding Path=ZKBFloatContentOpacity}"
+                                                    Minimum="0.1" Maximum="1.0" TickFrequency="0.05"
+                                                    TickPlacement="BottomRight" IsMoveToPointEnabled="True" />
+                                        </StackPanel>
+                                        <StackPanel Orientation="Horizontal" Margin="0,2">
+                                            <xctk:IntegerUpDown Value="{Binding Path=ZKBFloatMaxKills}"
+                                                                Minimum="10" Maximum="200" Width="70"
+                                                                Background="Transparent" Foreground="White" />
+                                            <Label Content="{DynamicResource Prefs_ZKB_FloatMax}" />
+                                        </StackPanel>
+                                        <CheckBox Margin="0,3" IsChecked="{Binding Path=ZKBFloatFilterByRegion}"
+                                                  Content="{DynamicResource Prefs_ZKB_FloatReg}" />
+                                    </StackPanel>
+                                </GroupBox>
+                            </Border>
                         </StackPanel>
                     </Grid>
                 </TabItem>

--- a/SMT/Preferences.xaml.cs
+++ b/SMT/Preferences.xaml.cs
@@ -482,8 +482,16 @@ namespace SMT
                     Application.Current.Resources.MergedDictionaries.Remove(oldLangDict);
                 }
 
-                // Update app language (static on EveManager; no Instance required)
                 SMT.EVEData.EveManager.CurrentLanguage = langCode;
+
+                if (MapConf != null)
+                    MapConf.Language = langCode;
+
+                // Refresh ZKB ship type display for current language
+                foreach (var item in EVEData.EveManager.Instance.ZKillFeed.KillStream)
+                {
+                    item.RefreshShipTypeDisplay();
+                }
 
                 // Redraw maps so labels use the new language
                 if (MainWindow.AppWindow != null)

--- a/SMT/Properties/Settings.Designer.cs
+++ b/SMT/Properties/Settings.Designer.cs
@@ -46,5 +46,17 @@ namespace SMT.Properties {
                 this["OverlayWindow_placement"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string ZKBMonitorWindow_placement {
+            get {
+                return ((string)(this["ZKBMonitorWindow_placement"]));
+            }
+            set {
+                this["ZKBMonitorWindow_placement"] = value;
+            }
+        }
     }
 }

--- a/SMT/Properties/Settings.settings
+++ b/SMT/Properties/Settings.settings
@@ -8,5 +8,8 @@
     <Setting Name="OverlayWindow_placement" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="ZKBMonitorWindow_placement" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/SMT/ZKBMonitor.xaml
+++ b/SMT/ZKBMonitor.xaml
@@ -1,0 +1,94 @@
+<Window x:Class="SMT.ZKBMonitor"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:SMT"
+        mc:Ignorable="d"
+        WindowStyle="None"
+        ResizeMode="CanResizeWithGrip"
+        Topmost="True"
+        Visibility="Visible"
+        MinWidth="200"
+        MinHeight="150"
+        Title="ZKB Monitor"
+        Height="400"
+        Width="320"
+        AllowsTransparency="True">
+    <Window.Resources>
+        <local:ZKBBackgroundConverter x:Key="zkbBGConverter" />
+        <local:ZKBForegroundConverter x:Key="zkbBGFConverter" />
+    </Window.Resources>
+    <Window.Background>
+        <SolidColorBrush Opacity="0.2" Color="Black" x:Name="windowBackground" />
+    </Window.Background>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="20" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="20" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="20" />
+        </Grid.ColumnDefinitions>
+
+        <Button Grid.Column="0" Grid.Row="0" PreviewMouseDown="ZKBMonitor_Window_Move"
+                Opacity="0.5" ToolTip="Drag to move" BorderThickness="0" Background="Transparent">
+            <Image Source="/Images/overlay_move.png" Stretch="Fill" />
+        </Button>
+
+        <TextBlock Grid.Column="1" Grid.Row="0"
+                   Background="Transparent" Name="zkb_TitleTextBlock"
+                   HorizontalAlignment="Center" TextAlignment="Center"
+                   FontSize="10" Opacity="0.5" Margin="1"
+                   Foreground="White" Text="ZKB Monitor" />
+
+        <Button Grid.Column="2" Grid.Row="0" PreviewMouseDown="ZKBMonitor_Window_Close"
+                Width="20" HorizontalAlignment="Right" Background="Transparent"
+                Opacity="0.5" ToolTip="Close" BorderThickness="0">
+            <Image Source="/Images/overlay_close.png" Stretch="Fill" />
+        </Button>
+
+        <DataGrid x:Name="ZKBKillList" Grid.Row="1" Grid.ColumnSpan="3"
+                  AreRowDetailsFrozen="True" Cursor="Hand"
+                  AutoGenerateColumns="False" CanUserAddRows="False"
+                  HeadersVisibility="Column" SelectionUnit="FullRow"
+                  GridLinesVisibility="None" MouseDoubleClick="ZKBKillList_MouseDoubleClick"
+                  Background="Transparent" Opacity="0.85">
+            <DataGrid.Columns>
+                <DataGridTextColumn Binding="{Binding SystemName}" Width="*"
+                                   IsReadOnly="True" CanUserReorder="False" CanUserSort="False">
+                    <DataGridTextColumn.Header>
+                        <TextBlock Text="{DynamicResource ZKB_Column_System}" />
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding VictimAllianceName}" Width="*"
+                                   IsReadOnly="True" CanUserReorder="False" CanUserSort="False">
+                    <DataGridTextColumn.Header>
+                        <TextBlock Text="{DynamicResource ZKB_Column_Alliance}" />
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding ShipTypeDisplay}" Width="*"
+                                   IsReadOnly="True" CanUserReorder="False" CanUserSort="False">
+                    <DataGridTextColumn.Header>
+                        <TextBlock Text="{DynamicResource ZKB_Column_ShipType}" />
+                    </DataGridTextColumn.Header>
+                </DataGridTextColumn>
+            </DataGrid.Columns>
+            <DataGrid.RowStyle>
+                <Style TargetType="{x:Type DataGridRow}">
+                    <Setter Property="Background" Value="{Binding Converter={StaticResource zkbBGConverter}}" />
+                    <Setter Property="Foreground" Value="{Binding Converter={StaticResource zkbBGFConverter}}" />
+                    <Setter Property="FontSize" Value="10" />
+                </Style>
+            </DataGrid.RowStyle>
+            <DataGrid.ContextMenu>
+                <ContextMenu>
+                    <MenuItem Header="{DynamicResource Main_ZKB_CtxShowSys}" Click="ContextMenu_ShowSystem_Click" />
+                    <MenuItem Header="{DynamicResource Main_ZKB_CtxOpen}" Click="ContextMenu_OpenZKB_Click" />
+                </ContextMenu>
+            </DataGrid.ContextMenu>
+        </DataGrid>
+    </Grid>
+</Window>

--- a/SMT/ZKBMonitor.xaml.cs
+++ b/SMT/ZKBMonitor.xaml.cs
@@ -1,0 +1,149 @@
+using System;
+using System.ComponentModel;
+using System.Windows;
+using System.Windows.Data;
+using System.Windows.Input;
+using System.Windows.Interop;
+
+namespace SMT
+{
+    public partial class ZKBMonitor : Window
+    {
+        private MainWindow mainWindow;
+        private bool filterByRegion = true;
+        private int maxKills = 50;
+
+        public ZKBMonitor(MainWindow mw)
+        {
+            InitializeComponent();
+
+            mainWindow = mw;
+            if (mainWindow == null) return;
+
+            ZKBKillList.ItemsSource = mainWindow.EVEManager.ZKillFeed.KillStream;
+
+            CollectionView view = (CollectionView)CollectionViewSource.GetDefaultView(ZKBKillList.ItemsSource);
+            view.Filter = item => ZKillFilter(item);
+
+            filterByRegion = mw.MapConf.ZKBFloatFilterByRegion;
+            maxKills = mw.MapConf.ZKBFloatMaxKills;
+
+            this.Background.Opacity = mw.MapConf.ZKBFloatBackgroundOpacity;
+            ZKBKillList.Opacity = mw.MapConf.ZKBFloatContentOpacity;
+
+            mainWindow.EVEManager.ZKillFeed.KillsAddedEvent += OnKillsAdded;
+            mw.MapConf.PropertyChanged += MapConf_PropertyChanged;
+
+            Closing += ZKBMonitor_Closing;
+        }
+
+        protected override void OnSourceInitialized(EventArgs e)
+        {
+            base.OnInitialized(e);
+            LoadWindowPosition();
+        }
+
+        private void LoadWindowPosition()
+        {
+            string placement = Properties.Settings.Default.ZKBMonitorWindow_placement;
+            if (!string.IsNullOrEmpty(placement))
+            {
+                WindowPlacement.SetPlacement(new WindowInteropHelper(this).Handle, placement);
+            }
+        }
+
+        private void StoreWindowPosition()
+        {
+            Properties.Settings.Default.ZKBMonitorWindow_placement =
+                WindowPlacement.GetPlacement(new WindowInteropHelper(this).Handle);
+            Properties.Settings.Default.Save();
+        }
+
+        private void ZKBMonitor_Closing(object sender, CancelEventArgs e)
+        {
+            StoreWindowPosition();
+            mainWindow.EVEManager.ZKillFeed.KillsAddedEvent -= OnKillsAdded;
+            mainWindow.MapConf.PropertyChanged -= MapConf_PropertyChanged;
+            mainWindow.MapConf.ZKBFloatWindowOpen = false;
+        }
+
+        private void ZKBMonitor_Window_Move(object sender, MouseButtonEventArgs e)
+        {
+            if (e.ChangedButton == MouseButton.Left)
+            {
+                this.ResizeMode = ResizeMode.NoResize;
+                this.DragMove();
+                this.ResizeMode = ResizeMode.CanResizeWithGrip;
+            }
+            e.Handled = true;
+        }
+
+        private void ZKBMonitor_Window_Close(object sender, MouseButtonEventArgs e)
+        {
+            this.Close();
+        }
+
+        private void ContextMenu_ShowSystem_Click(object sender, RoutedEventArgs e)
+        {
+            dynamic zs = ZKBKillList.SelectedItem;
+            if (zs != null)
+            {
+                mainWindow.RegionUC.SelectSystem(zs.SystemName, true);
+            }
+        }
+
+        private void ContextMenu_OpenZKB_Click(object sender, RoutedEventArgs e)
+        {
+            dynamic zs = ZKBKillList.SelectedItem;
+            if (zs != null)
+            {
+                string url = "https://zkillboard.com/kill/" + zs.KillID + "/";
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(url) { UseShellExecute = true });
+            }
+        }
+
+        private void ZKBKillList_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            dynamic zs = ZKBKillList.SelectedItem;
+            if (zs != null)
+            {
+                string url = "https://zkillboard.com/kill/" + zs.KillID + "/";
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(url) { UseShellExecute = true });
+            }
+        }
+
+        private void OnKillsAdded()
+        {
+            Application.Current.Dispatcher.Invoke(() =>
+            {
+                CollectionViewSource.GetDefaultView(ZKBKillList.ItemsSource)?.Refresh();
+            });
+        }
+
+        private bool ZKillFilter(object item)
+        {
+            if (!filterByRegion) return true;
+            dynamic zs = item;
+            if (zs != null)
+            {
+                return mainWindow.RegionUC?.Region?.IsSystemOnMap(zs.SystemName) ?? false;
+            }
+            return false;
+        }
+
+        private void MapConf_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == "ZKBFloatBackgroundOpacity")
+                this.Background.Opacity = mainWindow.MapConf.ZKBFloatBackgroundOpacity;
+            if (e.PropertyName == "ZKBFloatContentOpacity")
+                ZKBKillList.Opacity = mainWindow.MapConf.ZKBFloatContentOpacity;
+            if (e.PropertyName == "ZKBFloatFilterByRegion")
+            {
+                filterByRegion = mainWindow.MapConf.ZKBFloatFilterByRegion;
+                CollectionViewSource.GetDefaultView(ZKBKillList.ItemsSource)?.Refresh();
+            }
+            if (e.PropertyName == "ZKBFloatMaxKills")
+                maxKills = mainWindow.MapConf.ZKBFloatMaxKills;
+        }
+    }
+}

--- a/build-release.ps1
+++ b/build-release.ps1
@@ -1,0 +1,48 @@
+param(
+    [string]$OutputDir = "Release"
+)
+
+$ErrorActionPreference = "Stop"
+$PublishDir = "publish-single"
+
+Write-Host "=== 1. Clean ===" -ForegroundColor Cyan
+dotnet clean SMT.sln -c Release -p:Platform=x64 2>&1 | Out-Null
+if (Test-Path $PublishDir) { Remove-Item -Recurse -Force $PublishDir }
+
+Write-Host "=== 2. Publish single-file ===" -ForegroundColor Cyan
+dotnet publish SMT/SMT.csproj -c Release -p:Platform=x64 `
+    -p:PublishSingleFile=true `
+    -p:SelfContained=false `
+    -p:IncludeNativeLibrariesForSelfExtract=true `
+    -o $PublishDir
+if ($LASTEXITCODE -ne 0) { throw "Publish failed" }
+
+Write-Host "=== 3. Prepare output dir ===" -ForegroundColor Cyan
+if (Test-Path $OutputDir) { Remove-Item -Recurse -Force $OutputDir }
+New-Item -ItemType Directory -Path "$OutputDir/data"   -Force | Out-Null
+New-Item -ItemType Directory -Path "$OutputDir/sounds" -Force | Out-Null
+
+Write-Host "=== 4. Copy files ===" -ForegroundColor Cyan
+Copy-Item "$PublishDir/*.exe"              "$OutputDir/"
+Copy-Item "$PublishDir/*.pdb"              "$OutputDir/"
+Copy-Item "EVEData/data/*"                 "$OutputDir/data/" -Exclude "SourceMaps"
+Copy-Item "SMT/Sounds/*"                   "$OutputDir/sounds/"
+Copy-Item "SMT/DefaultWindowLayout.dat"    "$OutputDir/"
+
+# Cleanup publish temp dir
+Remove-Item -Recurse -Force $PublishDir
+
+Write-Host ""
+Write-Host "=== Done ===" -ForegroundColor Green
+$outFull = (Get-Item $OutputDir).FullName
+Write-Host "Output: $outFull"
+Write-Host ""
+
+Get-ChildItem $OutputDir -File | ForEach-Object {
+    $kb = "{0,8:N0} KB" -f ($_.Length / 1KB)
+    Write-Host "  $($_.Name)  $kb"
+}
+Get-ChildItem $OutputDir -Directory | ForEach-Object {
+    $cnt = (Get-ChildItem $_.FullName -Recurse -File).Count
+    Write-Host "  $($_.Name)/  ($cnt files)"
+}


### PR DESCRIPTION
- Add ZKBMonitor floating window showing real-time zkillboard kills with configurable opacity, max kills, and region filtering
- Fetch and cache Chinese ship type names from ESI, display when UI language is zh-CN
- Persist language selection across restarts by applying it before UI initialization
- Add ZKB float window preferences to the Preferences dialog (both en-US and zh-CN)
- Add ShipTypeDisplay property to ZKB data model for language-aware ship type display
- Add build-release.ps1 script for creating single-file releases