### PR TITLE
Fix #210

### DIFF
--- a/EVEData/EveManager.cs
+++ b/EVEData/EveManager.cs
@@ -2394,9 +2394,9 @@ namespace SMT.EVEData
         }
 
         /// <summary>
-        /// Save the Data to disk
+        /// Save the character data to disk.
         /// </summary>
-        public void SaveData()
+        public void SaveCharacters()
         {
             // save off only the ESI authenticated Characters so create a new copy to serialise from..
             List<LocalCharacter> saveList = new List<LocalCharacter>();
@@ -2416,6 +2416,14 @@ namespace SMT.EVEData
             {
                 xms.Serialize(tw, saveList);
             }
+        }
+
+        /// <summary>
+        /// Save the Data to disk
+        /// </summary>
+        public void SaveData()
+        {
+            SaveCharacters();
 
             string jbFileName = Path.Combine(SaveDataRootFolder, "JumpBridges_" + JumpBridge.SaveVersion + ".dat");
             Serialization.SerializeToDisk<List<JumpBridge>>(JumpBridges, jbFileName);

--- a/SMT/CharactersWindow.xaml.cs
+++ b/SMT/CharactersWindow.xaml.cs
@@ -45,6 +45,7 @@ namespace SMT
             }
 
             MainWindow mw = Owner as MainWindow;
+            mw.EVEManager.SaveCharacters();
             mw.EVEManager.LocalCharacterUpdateEvent -= EVEManager_LocalCharacterUpdateEvent;
         }
 

--- a/SMT/MainWindow.RoutingAndAnoms.cs
+++ b/SMT/MainWindow.RoutingAndAnoms.cs
@@ -417,11 +417,13 @@ namespace SMT
         }
         private void JumpPlannerShipType_OnSelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if(CapitalRoute != null)
+            if(CapitalRoute != null &&
+               sender is ComboBox cb &&
+               cb.SelectedItem is ComboBoxItem cbi &&
+               cbi.DataContext is string maxLYText &&
+               double.TryParse(maxLYText, NumberStyles.Float, CultureInfo.InvariantCulture, out double maxLY))
             {
-                ComboBox cb = sender as ComboBox;
-                ComboBoxItem cbi = cb.SelectedItem as ComboBoxItem;
-                CapitalRoute.MaxLY = double.Parse(cbi.DataContext as string);
+                CapitalRoute.MaxLY = maxLY;
                 CapitalRoute.Recalculate();
 
                 if(CapitalRoute.CurrentRoute.Count == 0)

--- a/SMT/MainWindow.xaml
+++ b/SMT/MainWindow.xaml
@@ -334,7 +334,7 @@
                                                             <ComboBoxItem DataContext="6.0" Content="{DynamicResource Main_JP_ShipAnsiblex}" />
                                                             <ComboBoxItem DataContext="6.0" Content="{DynamicResource Main_JP_ShipSuper}" />
                                                             <ComboBoxItem DataContext="7.0" IsSelected="True" Content="{DynamicResource Main_JP_ShipReg}" />
-                                                            <ComboBoxItem DataContext="7.5" IsSelected="True" Content="{DynamicResource Main_JP_ShipCommandCarrier}" />
+                                                            <ComboBoxItem DataContext="7.5" Content="{DynamicResource Main_JP_ShipCommandCarrier}" />
                                                             <ComboBoxItem DataContext="8.0" Content="{DynamicResource Main_JP_ShipBlops}" />
                                                             <ComboBoxItem DataContext="10.0" Content="{DynamicResource Main_JP_ShipJF}" />
                                                         </ComboBox>


### PR DESCRIPTION
Fixed an issue where selecting a ship type such as Super/Titan, Command Carrier, Black Ops, or JF/Rorqual could crash SMT. Ship jump ranges are now parsed using a culture-independent format. 

This prevents invalid values or parsing exceptions on systems using regional number formats. Also removed the duplicate default ship selection in the Jump Planner.