### PR TITLE
SMT Stability, Performance & Quality-of-Life Update

### DIFF
--- a/EVEData/EveManager.cs
+++ b/EVEData/EveManager.cs
@@ -2394,9 +2394,9 @@ namespace SMT.EVEData
         }
 
         /// <summary>
-        /// Save the Data to disk
+        /// Save the character data to disk.
         /// </summary>
-        public void SaveData()
+        public void SaveCharacters()
         {
             // save off only the ESI authenticated Characters so create a new copy to serialise from..
             List<LocalCharacter> saveList = new List<LocalCharacter>();
@@ -2416,6 +2416,14 @@ namespace SMT.EVEData
             {
                 xms.Serialize(tw, saveList);
             }
+        }
+
+        /// <summary>
+        /// Save the Data to disk
+        /// </summary>
+        public void SaveData()
+        {
+            SaveCharacters();
 
             string jbFileName = Path.Combine(SaveDataRootFolder, "JumpBridges_" + JumpBridge.SaveVersion + ".dat");
             Serialization.SerializeToDisk<List<JumpBridge>>(JumpBridges, jbFileName);

--- a/EVEData/EveManager.cs
+++ b/EVEData/EveManager.cs
@@ -49,7 +49,7 @@ namespace SMT.EVEData
         /// </summary>
         private static EveManager instance;
 
-        private bool BackgroundThreadShouldTerminate;
+        private volatile bool BackgroundThreadShouldTerminate;
 
         /// <summary>
         /// Thread-safe access lock for LocalCharacters collection
@@ -98,7 +98,7 @@ namespace SMT.EVEData
 
         private string VersionStr;
 
-        private bool WatcherThreadShouldTerminate;
+        private volatile bool WatcherThreadShouldTerminate;
 
         private TimeSpan CharacterUpdateRate = TimeSpan.FromSeconds(2);
         private TimeSpan LowFreqUpdateRate = TimeSpan.FromMinutes(20);
@@ -841,7 +841,7 @@ namespace SMT.EVEData
                 {
                     XmlResolver = null
                 };
-                FileStream fs = new FileStream(localSVG, FileMode.Open, FileAccess.Read);
+                using FileStream fs = new FileStream(localSVG, FileMode.Open, FileAccess.Read);
                 xmldoc.Load(fs);
 
                 // get the svg/g/g sys use child nodes
@@ -910,7 +910,7 @@ namespace SMT.EVEData
             string eveStaticDataSolarSystemFile = sourceFolder + @"\data\mapSolarSystems.csv";
             if(File.Exists(eveStaticDataSolarSystemFile))
             {
-                StreamReader file = new StreamReader(eveStaticDataSolarSystemFile);
+                using StreamReader file = new StreamReader(eveStaticDataSolarSystemFile);
 
                 // read the headers..
                 string line;
@@ -963,7 +963,7 @@ namespace SMT.EVEData
             string eveStaticDataRegionFile = sourceFolder + @"\data\mapRegions.csv";
             if(File.Exists(eveStaticDataRegionFile))
             {
-                StreamReader file = new StreamReader(eveStaticDataRegionFile);
+                using StreamReader file = new StreamReader(eveStaticDataRegionFile);
 
                 // read the headers..
                 string line;
@@ -994,7 +994,7 @@ namespace SMT.EVEData
             string eveStaticDataJumpsFile = sourceFolder + @"\data\mapSolarSystemJumps.csv";
             if(File.Exists(eveStaticDataJumpsFile))
             {
-                StreamReader file = new StreamReader(eveStaticDataJumpsFile);
+                using StreamReader file = new StreamReader(eveStaticDataJumpsFile);
 
                 // read the headers..
                 string line;
@@ -1034,7 +1034,7 @@ namespace SMT.EVEData
             string eveStaticDataJumpsExtraFile = sourceFolder + @"\data\mapSolarSystemJumpsExtra.csv";
             if(File.Exists(eveStaticDataJumpsExtraFile))
             {
-                StreamReader file = new StreamReader(eveStaticDataJumpsExtraFile);
+                using StreamReader file = new StreamReader(eveStaticDataJumpsExtraFile);
 
                 // read the headers..
                 string line;
@@ -1067,7 +1067,7 @@ namespace SMT.EVEData
             string eveStaticDataStationsFile = sourceFolder + @"\data\staStations.csv";
             if(File.Exists(eveStaticDataStationsFile))
             {
-                StreamReader file = new StreamReader(eveStaticDataStationsFile);
+                using StreamReader file = new StreamReader(eveStaticDataStationsFile);
 
                 // read the headers..
                 string line;
@@ -1094,7 +1094,7 @@ namespace SMT.EVEData
             string eveStaticDataConstellationFile = sourceFolder + @"\data\mapConstellations.csv";
             if(File.Exists(eveStaticDataConstellationFile))
             {
-                StreamReader file = new StreamReader(eveStaticDataConstellationFile);
+                using StreamReader file = new StreamReader(eveStaticDataConstellationFile);
 
                 Dictionary<string, string> constMap = new Dictionary<string, string>();
 
@@ -1128,7 +1128,7 @@ namespace SMT.EVEData
             string iceSystemsFile = sourceFolder + @"\data\iceSystems.csv";
             if(File.Exists(iceSystemsFile))
             {
-                StreamReader file = new StreamReader(iceSystemsFile);
+                using StreamReader file = new StreamReader(iceSystemsFile);
                 // read the headers..
                 string line;
                 line = file.ReadLine();
@@ -1150,7 +1150,7 @@ namespace SMT.EVEData
             string fwSystemsFile = sourceFolder + @"\data\factionWarfareSystems.csv";
             if(File.Exists(fwSystemsFile))
             {
-                StreamReader file = new StreamReader(fwSystemsFile);
+                using StreamReader file = new StreamReader(fwSystemsFile);
                 // read the headers..
                 string line;
                 line = file.ReadLine();
@@ -1172,7 +1172,7 @@ namespace SMT.EVEData
             string blueSunSystemsFile = sourceFolder + @"\data\a0BlueStarSystems.csv";
             if(File.Exists(blueSunSystemsFile))
             {
-                StreamReader file = new StreamReader(blueSunSystemsFile);
+                using StreamReader file = new StreamReader(blueSunSystemsFile);
                 // read the headers..
                 string line;
                 line = file.ReadLine();
@@ -1202,7 +1202,7 @@ namespace SMT.EVEData
             string trigSystemsFile = sourceFolder + @"\data\trigInvasionSystems.csv";
             if(File.Exists(trigSystemsFile))
             {
-                StreamReader file = new StreamReader(trigSystemsFile);
+                using StreamReader file = new StreamReader(trigSystemsFile);
 
                 // read the headers..
                 string line;
@@ -1696,7 +1696,7 @@ namespace SMT.EVEData
                 ValidShipGroupIDs.Add("1876"); //  Engineering Complex
                 ValidShipGroupIDs.Add("1924"); //  Forward Operating Base
 
-                StreamReader file = new StreamReader(eveStaticDataItemTypesFile);
+                using StreamReader file = new StreamReader(eveStaticDataItemTypesFile);
 
                 // read the headers..
                 string line;
@@ -1744,7 +1744,7 @@ namespace SMT.EVEData
             string eveStaticDataJoveObservatories = sourceFolder + @"\data\JoveSystems.csv";
             if(File.Exists(eveStaticDataJoveObservatories))
             {
-                StreamReader file = new StreamReader(eveStaticDataJoveObservatories);
+                using StreamReader file = new StreamReader(eveStaticDataJoveObservatories);
 
                 // read the headers..
                 string line;
@@ -1780,7 +1780,7 @@ namespace SMT.EVEData
             string eveStaticDataJoveGates = sourceFolder + @"\data\JoveGates.csv";
             if(File.Exists(eveStaticDataJoveGates))
             {
-                StreamReader file = new StreamReader(eveStaticDataJoveGates);
+                using StreamReader file = new StreamReader(eveStaticDataJoveGates);
                 string line;
                 while((line = file.ReadLine()) != null)
                 {
@@ -2246,7 +2246,7 @@ namespace SMT.EVEData
             string cynoBeaconsFile = Path.Combine(SaveDataRootFolder, "CynoBeacons.txt");
             if(File.Exists(cynoBeaconsFile))
             {
-                StreamReader file = new StreamReader(cynoBeaconsFile);
+                using StreamReader file = new StreamReader(cynoBeaconsFile);
 
                 string line;
                 while((line = file.ReadLine()) != null)
@@ -2279,13 +2279,11 @@ namespace SMT.EVEData
 
             try
             {
-                List<JumpBridge> loadList;
-                XmlSerializer xms = new XmlSerializer(typeof(List<JumpBridge>));
-
-                FileStream fs = new FileStream(dataFilename, FileMode.Open, FileAccess.Read);
-                XmlReader xmlr = XmlReader.Create(fs);
-
-                loadList = (List<JumpBridge>)xms.Deserialize(xmlr);
+                List<JumpBridge> loadList = Serialization.DeserializeFromDisk<List<JumpBridge>>(dataFilename);
+                if(loadList == null)
+                {
+                    return;
+                }
 
                 foreach(JumpBridge j in loadList)
                 {
@@ -2459,7 +2457,7 @@ namespace SMT.EVEData
 
             if(File.Exists(intelFileFilter))
             {
-                StreamReader file = new StreamReader(intelFileFilter);
+                using StreamReader file = new StreamReader(intelFileFilter);
                 string line;
                 while((line = file.ReadLine()) != null)
                 {
@@ -2480,7 +2478,7 @@ namespace SMT.EVEData
 
             if(File.Exists(intelClearFileFilter))
             {
-                StreamReader file = new StreamReader(intelClearFileFilter);
+                using StreamReader file = new StreamReader(intelClearFileFilter);
                 string line;
                 while((line = file.ReadLine()) != null)
                 {
@@ -2503,7 +2501,7 @@ namespace SMT.EVEData
 
             if(File.Exists(intelIgnoreFileFilter))
             {
-                StreamReader file = new StreamReader(intelIgnoreFileFilter);
+                using StreamReader file = new StreamReader(intelIgnoreFileFilter);
                 string line;
                 while((line = file.ReadLine()) != null)
                 {
@@ -2525,7 +2523,7 @@ namespace SMT.EVEData
 
             if(File.Exists(intelAlertFileFilter))
             {
-                StreamReader file = new StreamReader(intelAlertFileFilter);
+                using StreamReader file = new StreamReader(intelAlertFileFilter);
                 string line;
                 while((line = file.ReadLine()) != null)
                 {
@@ -2623,7 +2621,7 @@ namespace SMT.EVEData
 
         private void LogFileCacheTrigger(List<string> eveLogFolders)
         {
-            Thread.CurrentThread.IsBackground = false;
+            Thread.CurrentThread.IsBackground = true;
 
             foreach(string dir in eveLogFolders)
             {
@@ -2667,9 +2665,8 @@ namespace SMT.EVEData
                         // only read files from the last day
                         if(file.CreationTime > DateTime.Now.AddDays(-1) && readFile)
                         {
-                            FileStream ifs = new FileStream(file.FullName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                            using FileStream ifs = new FileStream(file.FullName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
                             ifs.Seek(0, SeekOrigin.End);
-                            ifs.Close();
                         }
                     }
 
@@ -3144,7 +3141,7 @@ namespace SMT.EVEData
                 string POIcsv = Path.Combine(DataRootFolder, "POI.csv");
                 if(File.Exists(POIcsv))
                 {
-                    StreamReader file = new StreamReader(POIcsv);
+                    using StreamReader file = new StreamReader(POIcsv);
 
                     string line;
                     line = file.ReadLine();
@@ -3271,9 +3268,9 @@ namespace SMT.EVEData
                 try
                 {
                     Encoding fe = Misc.GetEncoding(changedFile);
-                    FileStream ifs = new FileStream(changedFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                    using FileStream ifs = new FileStream(changedFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
 
-                    StreamReader file = new StreamReader(ifs, fe);
+                    using StreamReader file = new StreamReader(ifs, fe);
 
                     int fileReadFrom = 0;
 
@@ -3460,8 +3457,6 @@ namespace SMT.EVEData
                         line = file.ReadLine();
                     }
 
-                    ifs.Close();
-
                     intelFileReadPos[changedFile] = fileReadFrom;
                 }
                 catch
@@ -3484,9 +3479,9 @@ namespace SMT.EVEData
             try
             {
                 Encoding fe = EVEDataUtils.Misc.GetEncoding(changedFile);
-                FileStream ifs = new FileStream(changedFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                using FileStream ifs = new FileStream(changedFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
 
-                StreamReader file = new StreamReader(ifs, fe);
+                using StreamReader file = new StreamReader(ifs, fe);
 
                 int fileReadFrom = 0;
 
@@ -3631,8 +3626,6 @@ namespace SMT.EVEData
                     gameFileReadPos[changedFile] = fileReadFrom;
                 }
 
-                ifs.Close();
-
                 gameFileReadPos[changedFile] = fileReadFrom;
             }
             catch
@@ -3653,13 +3646,11 @@ namespace SMT.EVEData
 
             try
             {
-                List<LocalCharacter> loadList;
-                XmlSerializer xms = new XmlSerializer(typeof(List<LocalCharacter>));
-
-                FileStream fs = new FileStream(dataFilename, FileMode.Open, FileAccess.Read);
-                XmlReader xmlr = XmlReader.Create(fs);
-
-                loadList = (List<LocalCharacter>)xms.Deserialize(xmlr);
+                List<LocalCharacter> loadList = Serialization.DeserializeFromDisk<List<LocalCharacter>>(dataFilename);
+                if(loadList == null)
+                {
+                    return;
+                }
 
                 foreach(LocalCharacter c in loadList)
                 {
@@ -3684,7 +3675,7 @@ namespace SMT.EVEData
         {
             new Thread(async () =>
             {
-                Thread.CurrentThread.IsBackground = false;
+                Thread.CurrentThread.IsBackground = true;
 
 
                 // split the intial requests into 3 for a better initialisation

--- a/EVEData/EveManager.cs
+++ b/EVEData/EveManager.cs
@@ -49,12 +49,21 @@ namespace SMT.EVEData
         /// </summary>
         private static EveManager instance;
 
-        private volatile bool BackgroundThreadShouldTerminate;
+        private readonly CancellationTokenSource backgroundCancellation = new CancellationTokenSource();
+        private CancellationTokenSource watcherCancellation = new CancellationTokenSource();
+        private Task backgroundUpdateTask = Task.CompletedTask;
+        private Task logFileCacheTask = Task.CompletedTask;
+        private readonly HttpClient httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+        private int shutdownRequested;
+        private int shutdownCleanupScheduled;
 
         /// <summary>
         /// Thread-safe access lock for LocalCharacters collection
         /// </summary>
         private readonly object _localCharactersLock = new object();
+        private readonly object intelLogLock = new object();
+        private readonly object gameLogLock = new object();
+        private readonly object identityCacheLock = new object();
 
         /// <summary>
         /// Observable collection for LocalCharacters that supports UI binding
@@ -97,8 +106,6 @@ namespace SMT.EVEData
         private FileSystemWatcher gameLogFileWatcher;
 
         private string VersionStr;
-
-        private volatile bool WatcherThreadShouldTerminate;
 
         private TimeSpan CharacterUpdateRate = TimeSpan.FromSeconds(2);
         private TimeSpan LowFreqUpdateRate = TimeSpan.FromMinutes(20);
@@ -151,10 +158,9 @@ namespace SMT.EVEData
                 }
 
             }
-            catch
+            catch(Exception exception)
             {
-                // if we fail to migrate the settings, we just ignore it
-                // this is a one time migration so we don't need to worry about it again
+                AppLog.Error("Migrate settings", exception);
             }
 
 
@@ -170,6 +176,7 @@ namespace SMT.EVEData
             VersionStr = version;
 
             MigrateOldSettings();
+            AppLog.Initialize(Path.Combine(EveAppConfig.StorageRoot, "Logs"));
 
             string SaveDataRoot = EveAppConfig.StorageRoot;
             if (!Directory.Exists(SaveDataRoot))
@@ -367,7 +374,7 @@ namespace SMT.EVEData
         /// </summary>
         public event LocalCharactersUpdatedHandler LocalCharacterUpdateEvent;
 
-        public List<SOVCampaign> ActiveSovCampaigns { get; set; }
+        public ObservableCollection<SOVCampaign> ActiveSovCampaigns { get; set; }
 
         /// <summary>
         /// Gets or sets the Alliance ID to Name dictionary
@@ -463,6 +470,18 @@ namespace SMT.EVEData
         /// Delegate for UI thread operations
         /// </summary>
         public static Action<Action> UIThreadInvoker { get; set; }
+
+        private static void RunOnUIThread(Action action)
+        {
+            if(UIThreadInvoker != null)
+            {
+                UIThreadInvoker(action);
+            }
+            else
+            {
+                action();
+            }
+        }
 
         /// <summary>
         /// Thread-safe add character method
@@ -1979,13 +1998,10 @@ namespace SMT.EVEData
         /// <returns>Alliance Name</returns>
         public string GetAllianceName(int id)
         {
-            string name = string.Empty;
-            if(AllianceIDToName.ContainsKey(id))
+            lock(identityCacheLock)
             {
-                name = AllianceIDToName[id];
+                return AllianceIDToName.TryGetValue(id, out string name) ? name : string.Empty;
             }
-
-            return name;
         }
 
         /// <summary>
@@ -1995,24 +2011,18 @@ namespace SMT.EVEData
         /// <returns>Alliance Ticker</returns>
         public string GetAllianceTicker(int id)
         {
-            string ticker = string.Empty;
-            if(AllianceIDToTicker.ContainsKey(id))
+            lock(identityCacheLock)
             {
-                ticker = AllianceIDToTicker[id];
+                return AllianceIDToTicker.TryGetValue(id, out string ticker) ? ticker : string.Empty;
             }
-
-            return ticker;
         }
 
         public string GetCharacterName(int id)
         {
-            string name = string.Empty;
-            if(CharacterIDToName.ContainsKey(id))
+            lock(identityCacheLock)
             {
-                name = CharacterIDToName[id];
+                return CharacterIDToName.TryGetValue(id, out string name) ? name : string.Empty;
             }
-
-            return name;
         }
 
         /// <summary>
@@ -2146,7 +2156,7 @@ namespace SMT.EVEData
         /// <summary>
         /// Hand the custom smtauth- url we get back from the logon screen
         /// </summary>
-        public async void HandleEveAuthSMTUri(Uri uri, string challengeCode)
+        public async Task HandleEveAuthSMTUriAsync(Uri uri, string challengeCode)
         {
             var query = HttpUtility.ParseQueryString(uri.Query);
             if (query["code"] == null)
@@ -2164,8 +2174,9 @@ namespace SMT.EVEData
                 if (tokenDetails == null || tokenDetails.ExpiresIn <= 0)
                     return;
             }
-            catch
+            catch(Exception exception)
             {
+                AppLog.Error("ESI authorization", exception);
                 return;
             }
 
@@ -2176,8 +2187,9 @@ namespace SMT.EVEData
                 if (characterDetails == null)
                     return;
             }
-            catch
+            catch(Exception exception)
             {
+                AppLog.Error("ESI character details", exception);
                 return;
             }
 
@@ -2290,8 +2302,9 @@ namespace SMT.EVEData
                     JumpBridges.Add(j);
                 }
             }
-            catch
+            catch(Exception exception)
             {
+                AppLog.Error("Load jump bridges", exception);
             }
         }
 
@@ -2307,11 +2320,14 @@ namespace SMT.EVEData
 
             // strip out any ID's we already know..
             List<int> UnknownIDs = new List<int>();
-            foreach(int l in IDs)
+            lock(identityCacheLock)
             {
-                if((!AllianceIDToName.ContainsKey(l) || !AllianceIDToTicker.ContainsKey(l)) && !UnknownIDs.Contains(l))
+                foreach(int l in IDs)
                 {
-                    UnknownIDs.Add(l);
+                    if((!AllianceIDToName.ContainsKey(l) || !AllianceIDToTicker.ContainsKey(l)) && !UnknownIDs.Contains(l))
+                    {
+                        UnknownIDs.Add(l);
+                    }
                 }
             }
 
@@ -2333,19 +2349,28 @@ namespace SMT.EVEData
                             var esraA = await EveApiClient.Alliance.GetAllianceInfoAsync(ri.Id);
                             if (ESIHelpers.ValidateESICall(esraA))
                             {
-                                AllianceIDToTicker[(int)ri.Id] = esraA.Model.Ticker;
-                                AllianceIDToName[(int)ri.Id] = esraA.Model.Name;
+                                lock(identityCacheLock)
+                                {
+                                    AllianceIDToTicker[(int)ri.Id] = esraA.Model.Ticker;
+                                    AllianceIDToName[(int)ri.Id] = esraA.Model.Name;
+                                }
                             }
                             else
                             {
-                                AllianceIDToTicker[(int)ri.Id] = "???????????????";
-                                AllianceIDToName[(int)ri.Id] = "?????";
+                                lock(identityCacheLock)
+                                {
+                                    AllianceIDToTicker[(int)ri.Id] = "???????????????";
+                                    AllianceIDToName[(int)ri.Id] = "?????";
+                                }
                             }
                         }
                     }
                 }
             }
-            catch { }
+            catch(Exception exception)
+            {
+                AppLog.Error("Resolve alliance IDs", exception);
+            }
         }
 
         /// <summary>
@@ -2360,11 +2385,14 @@ namespace SMT.EVEData
 
             // strip out any ID's we already know..
             List<int> UnknownIDs = new List<int>();
-            foreach(int l in IDs)
+            lock(identityCacheLock)
             {
-                if(!CharacterIDToName.ContainsKey(l))
+                foreach(int l in IDs)
                 {
-                    UnknownIDs.Add(l);
+                    if(!CharacterIDToName.ContainsKey(l))
+                    {
+                        UnknownIDs.Add(l);
+                    }
                 }
             }
 
@@ -2383,12 +2411,18 @@ namespace SMT.EVEData
                     {
                         if (ri.Category == "character")
                         {
-                            CharacterIDToName[(int)ri.Id] = ri.Name;
+                            lock(identityCacheLock)
+                            {
+                                CharacterIDToName[(int)ri.Id] = ri.Name;
+                            }
                         }
                     }
                 }
             }
-            catch { }
+            catch(Exception exception)
+            {
+                AppLog.Error("Resolve character IDs", exception);
+            }
         }
 
         /// <summary>
@@ -2407,13 +2441,8 @@ namespace SMT.EVEData
                 }
             }
 
-            XmlSerializer xms = new XmlSerializer(typeof(List<LocalCharacter>));
             string dataFilename = Path.Combine(SaveDataRootFolder, "Characters_" + LocalCharacter.SaveVersion + ".dat");
-
-            using(TextWriter tw = new StreamWriter(dataFilename))
-            {
-                xms.Serialize(tw, saveList);
-            }
+            Serialization.SerializeToDisk(saveList, dataFilename);
         }
 
         /// <summary>
@@ -2436,22 +2465,27 @@ namespace SMT.EVEData
             }
 
             // save the intel channels / intel filters
-            File.WriteAllLines(Path.Combine(SaveDataRootFolder, "IntelChannels.txt"), IntelFilters);
-            File.WriteAllLines(Path.Combine(SaveDataRootFolder, "IntelClearFilters.txt"), IntelClearFilters);
-            File.WriteAllLines(Path.Combine(SaveDataRootFolder, "IntelIgnoreFilters.txt"), IntelIgnoreFilters);
-            File.WriteAllLines(Path.Combine(SaveDataRootFolder, "IntelAlertFilters.txt"), IntelAlertFilters);
-            File.WriteAllLines(Path.Combine(SaveDataRootFolder, "CynoBeacons.txt"), beaconsToSave);
+            AtomicFile.WriteAllLines(Path.Combine(SaveDataRootFolder, "IntelChannels.txt"), IntelFilters);
+            AtomicFile.WriteAllLines(Path.Combine(SaveDataRootFolder, "IntelClearFilters.txt"), IntelClearFilters);
+            AtomicFile.WriteAllLines(Path.Combine(SaveDataRootFolder, "IntelIgnoreFilters.txt"), IntelIgnoreFilters);
+            AtomicFile.WriteAllLines(Path.Combine(SaveDataRootFolder, "IntelAlertFilters.txt"), IntelAlertFilters);
+            AtomicFile.WriteAllLines(Path.Combine(SaveDataRootFolder, "CynoBeacons.txt"), beaconsToSave);
         }
 
         /// <summary>
         /// Setup the intel watcher;  Loads the intel channel filter list and creates the file system watchers
         /// </summary>
-        public void SetupIntelWatcher()
+        public void SetupIntelWatcher(bool resetState = true)
         {
-            IntelDataList = new FixedQueue<IntelData>();
-            IntelDataList.SetSizeLimit(250);
+            lock(intelLogLock)
+            {
+                DisposeIntelFileWatcher();
+                if(resetState)
+                {
+                    IntelDataList = new FixedQueue<IntelData>();
+                    IntelDataList.SetSizeLimit(250);
 
-            IntelFilters = new List<string>();
+                    IntelFilters = new List<string>();
 
             string intelFileFilter = Path.Combine(SaveDataRootFolder, "IntelChannels.txt");
 
@@ -2518,7 +2552,7 @@ namespace SMT.EVEData
                 IntelIgnoreFilters.Add("Status");
             }
 
-            IntelAlertFilters = new List<string>();
+                    IntelAlertFilters = new List<string>();
             string intelAlertFileFilter = Path.Combine(SaveDataRootFolder, "IntelAlertFilters.txt");
 
             if(File.Exists(intelAlertFileFilter))
@@ -2540,7 +2574,9 @@ namespace SMT.EVEData
                 IntelAlertFilters.Add("");
             }
 
-            intelFileReadPos = new Dictionary<string, int>();
+                }
+
+                intelFileReadPos = new Dictionary<string, int>();
 
             if(string.IsNullOrEmpty(EVELogFolder) || !Directory.Exists(EVELogFolder))
             {
@@ -2550,28 +2586,37 @@ namespace SMT.EVEData
 
             string chatlogFolder = Path.Combine(EVELogFolder, "Chatlogs");
 
-            if(Directory.Exists(chatlogFolder))
-            {
-                intelFileWatcher = new FileSystemWatcher(chatlogFolder)
+                if(Directory.Exists(chatlogFolder))
                 {
-                    Filter = "*.txt",
-                    EnableRaisingEvents = true,
-                    NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.Size
-                };
-                intelFileWatcher.Changed += IntelFileWatcher_Changed;
+                    intelFileWatcher = new FileSystemWatcher(chatlogFolder)
+                    {
+                        Filter = "*.txt",
+                        NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.Size,
+                        InternalBufferSize = 32 * 1024,
+                    };
+                    intelFileWatcher.Changed += IntelFileWatcher_Changed;
+                    intelFileWatcher.Error += LogFileWatcher_Error;
+                    intelFileWatcher.EnableRaisingEvents = true;
+                }
             }
         }
 
         /// <summary>
         /// Setup the game log0 watcher
         /// </summary>
-        public void SetupGameLogWatcher()
+        public void SetupGameLogWatcher(bool resetState = true)
         {
-            gameFileReadPos = new Dictionary<string, int>();
-            gamelogFileCharacterMap = new Dictionary<string, string>();
+            lock(gameLogLock)
+            {
+                DisposeGameLogFileWatcher();
+                gameFileReadPos = new Dictionary<string, int>();
+                gamelogFileCharacterMap = new Dictionary<string, string>();
 
-            GameLogList = new FixedQueue<GameLogData>();
-            GameLogList.SetSizeLimit(50);
+                if(resetState)
+                {
+                    GameLogList = new FixedQueue<GameLogData>();
+                    GameLogList.SetSizeLimit(50);
+                }
 
             if(string.IsNullOrEmpty(EVELogFolder) || !Directory.Exists(EVELogFolder))
             {
@@ -2581,15 +2626,18 @@ namespace SMT.EVEData
 
             string gameLogFolder = Path.Combine(EVELogFolder, "Gamelogs");
 
-            if(Directory.Exists(gameLogFolder))
-            {
-                gameLogFileWatcher = new FileSystemWatcher(gameLogFolder)
+                if(Directory.Exists(gameLogFolder))
                 {
-                    Filter = "*.txt",
-                    EnableRaisingEvents = true,
-                    NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.Size
-                };
-                gameLogFileWatcher.Changed += GameLogFileWatcher_Changed;
+                    gameLogFileWatcher = new FileSystemWatcher(gameLogFolder)
+                    {
+                        Filter = "*.txt",
+                        NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.Size,
+                        InternalBufferSize = 32 * 1024,
+                    };
+                    gameLogFileWatcher.Changed += GameLogFileWatcher_Changed;
+                    gameLogFileWatcher.Error += LogFileWatcher_Error;
+                    gameLogFileWatcher.EnableRaisingEvents = true;
+                }
             }
         }
 
@@ -2610,19 +2658,27 @@ namespace SMT.EVEData
             logFolders.Add(chatLogFolder);
             logFolders.Add(gameLogFolder);
 
-            new Thread(() =>
+            Task previousCacheTask = logFileCacheTask;
+            CancellationToken cancellationToken = watcherCancellation.Token;
+            logFileCacheTask = Task.Run(async () =>
             {
-                LogFileCacheTrigger(logFolders);
-            }).Start();
+                try
+                {
+                    await previousCacheTask.ConfigureAwait(false);
+                }
+                catch(OperationCanceledException)
+                {
+                }
+
+                await LogFileCacheTriggerAsync(logFolders, cancellationToken).ConfigureAwait(false);
+            });
 
             // END SUPERHACK
             // -----------------------------------------------------------------
         }
 
-        private void LogFileCacheTrigger(List<string> eveLogFolders)
+        private async Task LogFileCacheTriggerAsync(List<string> eveLogFolders, CancellationToken cancellationToken)
         {
-            Thread.CurrentThread.IsBackground = true;
-
             foreach(string dir in eveLogFolders)
             {
                 if(!Directory.Exists(dir))
@@ -2632,87 +2688,176 @@ namespace SMT.EVEData
             }
 
             // loop forever
-            while(WatcherThreadShouldTerminate == false)
+            try
             {
-                foreach(string folder in eveLogFolders)
+                while(!cancellationToken.IsCancellationRequested)
                 {
-                    DirectoryInfo di = new DirectoryInfo(folder);
-                    FileInfo[] files = di.GetFiles("*.txt");
-                    foreach(FileInfo file in files)
+                    DateTime recentThreshold = DateTime.UtcNow.AddMinutes(-10);
+                    foreach(string folder in eveLogFolders)
                     {
-                        bool readFile = false;
-                        foreach(string intelFilterStr in IntelFilters)
+                        DirectoryInfo di = new DirectoryInfo(folder);
+                        IEnumerable<FileInfo> files = di.EnumerateFiles("*.txt")
+                            .Where(file => file.LastWriteTimeUtc >= recentThreshold);
+
+                        foreach(FileInfo file in files)
                         {
-                            if(file.Name.Contains(intelFilterStr, StringComparison.OrdinalIgnoreCase))
+                            bool readFile = false;
+                            foreach(string intelFilterStr in IntelFilters)
+                            {
+                                if(file.Name.Contains(intelFilterStr, StringComparison.OrdinalIgnoreCase))
+                                {
+                                    readFile = true;
+                                    break;
+                                }
+                            }
+
+                            // local files
+                            if(file.Name.Contains("Local_", StringComparison.OrdinalIgnoreCase))
                             {
                                 readFile = true;
-                                break;
                             }
-                        }
 
-                        // local files
-                        if(file.Name.Contains("Local_"))
-                        {
-                            readFile = true;
-                        }
+                            // gamelogs
+                            if(folder.Contains("Gamelogs", StringComparison.OrdinalIgnoreCase))
+                            {
+                                readFile = true;
+                            }
 
-                        // gamelogs
-                        if(folder.Contains("Gamelogs"))
-                        {
-                            readFile = true;
-                        }
-
-                        // only read files from the last day
-                        if(file.CreationTime > DateTime.Now.AddDays(-1) && readFile)
-                        {
-                            using FileStream ifs = new FileStream(file.FullName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                            ifs.Seek(0, SeekOrigin.End);
+                            if(readFile)
+                            {
+                                using FileStream ifs = new FileStream(file.FullName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                                ifs.Seek(0, SeekOrigin.End);
+                            }
                         }
                     }
 
-                    Thread.Sleep(1500);
+                    await Task.Delay(TimeSpan.FromMilliseconds(1500), cancellationToken).ConfigureAwait(false);
                 }
             }
+            catch(OperationCanceledException) when(cancellationToken.IsCancellationRequested)
+            {
+            }
+            catch(Exception exception)
+            {
+                AppLog.Error("EVE log cache watcher", exception);
+            }
         }
 
-        public void ShuddownIntelWatcher()
+        public bool ReloadLogWatchers(string logFolder)
         {
-            if(intelFileWatcher != null)
+            string resolvedFolder = string.IsNullOrWhiteSpace(logFolder)
+                ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "EVE", "Logs")
+                : Path.GetFullPath(logFolder);
+
+            string chatFolder = Path.Combine(resolvedFolder, "Chatlogs");
+            string gameFolder = Path.Combine(resolvedFolder, "Gamelogs");
+            if(!Directory.Exists(chatFolder) || !Directory.Exists(gameFolder))
             {
-                intelFileWatcher.Changed -= IntelFileWatcher_Changed;
+                AppLog.Warning("EVE log folder", $"The selected folder does not contain Chatlogs and Gamelogs: {resolvedFolder}");
+                return false;
             }
-            WatcherThreadShouldTerminate = true;
+
+            CancellationTokenSource previousCancellation = watcherCancellation;
+            StopLogWatchers();
+            watcherCancellation = new CancellationTokenSource();
+            _ = logFileCacheTask.ContinueWith(
+                _ => previousCancellation.Dispose(),
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+            EVELogFolder = resolvedFolder;
+
+            SetupIntelWatcher(false);
+            SetupGameLogWatcher(false);
+            SetupLogFileTriggers();
+            AppLog.Info("EVE log folder", $"Now monitoring {resolvedFolder}");
+            return true;
         }
 
-        public void ShuddownGameLogWatcher()
+        private void StopLogWatchers()
         {
-            if(gameLogFileWatcher != null)
+            watcherCancellation.Cancel();
+            DisposeIntelFileWatcher();
+            DisposeGameLogFileWatcher();
+        }
+
+        private void DisposeIntelFileWatcher()
+        {
+            if(intelFileWatcher == null)
             {
-                gameLogFileWatcher.Changed -= GameLogFileWatcher_Changed;
+                return;
             }
-            WatcherThreadShouldTerminate = true;
+
+            intelFileWatcher.EnableRaisingEvents = false;
+            intelFileWatcher.Changed -= IntelFileWatcher_Changed;
+            intelFileWatcher.Error -= LogFileWatcher_Error;
+            intelFileWatcher.Dispose();
+            intelFileWatcher = null;
+        }
+
+        private void DisposeGameLogFileWatcher()
+        {
+            if(gameLogFileWatcher == null)
+            {
+                return;
+            }
+
+            gameLogFileWatcher.EnableRaisingEvents = false;
+            gameLogFileWatcher.Changed -= GameLogFileWatcher_Changed;
+            gameLogFileWatcher.Error -= LogFileWatcher_Error;
+            gameLogFileWatcher.Dispose();
+            gameLogFileWatcher = null;
+        }
+
+        private void LogFileWatcher_Error(object sender, ErrorEventArgs e)
+        {
+            AppLog.Error("EVE log watcher", e.GetException());
+        }
+
+        public void BeginShutdown()
+        {
+            if(Interlocked.Exchange(ref shutdownRequested, 1) != 0)
+            {
+                return;
+            }
+
+            backgroundCancellation.Cancel();
+            StopLogWatchers();
+            ZKillFeed?.ShutDown();
         }
 
         public void ShutDown()
         {
-            ShuddownIntelWatcher();
-            ShuddownGameLogWatcher();
-            BackgroundThreadShouldTerminate = true;
+            BeginShutdown();
+            if(Interlocked.Exchange(ref shutdownCleanupScheduled, 1) != 0)
+            {
+                return;
+            }
 
-            ZKillFeed.ShutDown();
+            _ = Task.WhenAll(backgroundUpdateTask, logFileCacheTask, ZKillFeed?.Completion ?? Task.CompletedTask)
+                .ContinueWith(_ =>
+                {
+                    ZKillFeed?.Dispose();
+                    ServerInfo?.Dispose();
+                    httpClient.Dispose();
+                    watcherCancellation.Dispose();
+                    backgroundCancellation.Dispose();
+                }, TaskScheduler.Default);
         }
 
         /// <summary>
         /// Update The Universe Data from the various ESI end points
         /// </summary>
-        public void UpdateESIUniverseData()
+        public async Task UpdateESIUniverseDataAsync(CancellationToken cancellationToken = default)
         {
-            UpdateKillsFromESI();
-            UpdateJumpsFromESI();
-            UpdateSOVFromESI();
-            UpdateIncursionsFromESI();
+            await Task.WhenAll(
+                UpdateKillsFromESIAsync(),
+                UpdateJumpsFromESIAsync(),
+                UpdateIncursionsFromESIAsync()).ConfigureAwait(false);
 
-            UpdateSovStructureUpdate();
+            cancellationToken.ThrowIfCancellationRequested();
+            await UpdateSOVFromESIAsync(cancellationToken).ConfigureAwait(false);
+            await UpdateSovStructureUpdateAsync().ConfigureAwait(false);
 
             // TEMP Disabled
             //();
@@ -2733,7 +2878,9 @@ namespace SMT.EVEData
 
             foreach(KeyValuePair<string, MapSystem> kvp in r.MapSystems)
             {
-                if(kvp.Value.ActualSystem.SOVAllianceID != 0 && !AllianceIDToName.ContainsKey(kvp.Value.ActualSystem.SOVAllianceID) && !IDToResolve.Contains(kvp.Value.ActualSystem.SOVAllianceID))
+                if(kvp.Value.ActualSystem.SOVAllianceID != 0 &&
+                   string.IsNullOrEmpty(GetAllianceName(kvp.Value.ActualSystem.SOVAllianceID)) &&
+                   !IDToResolve.Contains(kvp.Value.ActualSystem.SOVAllianceID))
                 {
                     IDToResolve.Add(kvp.Value.ActualSystem.SOVAllianceID);
                 }
@@ -2745,21 +2892,19 @@ namespace SMT.EVEData
         /// <summary>
         /// Update the current Thera Connections from EVE-Scout
         /// </summary>
-        public async void UpdateTheraConnections()
+        public async Task UpdateTheraConnectionsAsync(CancellationToken cancellationToken = default)
         {
             string theraApiURL = "https://api.eve-scout.com/v2/public/signatures?system_name=Thera";
             string strContent = string.Empty;
+            List<TheraConnection> refreshedConnections = new List<TheraConnection>();
 
             try
             {
-                HttpClient hc = new HttpClient();
-                var response = await hc.GetAsync(theraApiURL);
+                using HttpResponseMessage response = await httpClient.GetAsync(theraApiURL, cancellationToken).ConfigureAwait(false);
                 response.EnsureSuccessStatusCode();
-                strContent = await response.Content.ReadAsStringAsync();
+                strContent = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 
                 JsonTextReader jsr = new JsonTextReader(new StringReader(strContent));
-
-                TheraConnections.Clear();
 
                 /*
                     new format
@@ -2797,51 +2942,59 @@ namespace SMT.EVEData
                     if(jsr.TokenType == JsonToken.StartObject)
                     {
                         JObject obj = JObject.Load(jsr);
-                        string inSignatureId = obj["in_signature"].ToString();
-                        string outSignatureId = obj["out_signature"].ToString();
-                        long solarSystemId = long.Parse(obj["in_system_id"].ToString());
-                        string wormHoleEOL = obj["expires_at"].ToString();
-                        string type = obj["signature_type"].ToString();
+                        string inSignatureId = obj["in_signature"]?.ToString();
+                        string outSignatureId = obj["out_signature"]?.ToString();
+                        string wormHoleEOL = obj["expires_at"]?.ToString();
+                        string type = obj["signature_type"]?.ToString();
 
-                        if(type != null && type == "wormhole" && solarSystemId != 0 && wormHoleEOL != null && SystemIDToName.ContainsKey(solarSystemId))
+                        if(type == "wormhole" &&
+                           long.TryParse(obj["in_system_id"]?.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out long solarSystemId) &&
+                           solarSystemId != 0 &&
+                           !string.IsNullOrEmpty(wormHoleEOL) &&
+                           SystemIDToName.ContainsKey(solarSystemId))
                         {
                             System theraConnectionSystem = GetEveSystemFromID(solarSystemId);
 
                             TheraConnection tc = new TheraConnection(theraConnectionSystem.Name, theraConnectionSystem.Region, inSignatureId, outSignatureId, wormHoleEOL);
-                            TheraConnections.Add(tc);
+                            refreshedConnections.Add(tc);
                         }
                     }
                 }
             }
-            catch
+            catch(OperationCanceledException) when(cancellationToken.IsCancellationRequested)
             {
                 return;
             }
-
-            if(TheraUpdateEvent != null)
+            catch(Exception exception)
             {
-                TheraUpdateEvent();
+                AppLog.Error("Thera connections", exception);
+                return;
             }
+
+            RunOnUIThread(() =>
+            {
+                TheraConnections.Clear();
+                TheraConnections.AddRange(refreshedConnections);
+                TheraUpdateEvent?.Invoke();
+            });
         }
 
         /// <summary>
         /// Update the current Turnur Connections from EVE-Scout
         /// </summary>
-        public async void UpdateTurnurConnections()
+        public async Task UpdateTurnurConnectionsAsync(CancellationToken cancellationToken = default)
         {
             string turnurApiURL = "https://api.eve-scout.com/v2/public/signatures?system_name=Turnur";
             string strContent = string.Empty;
+            List<TurnurConnection> refreshedConnections = new List<TurnurConnection>();
 
             try
             {
-                HttpClient hc = new HttpClient();
-                var response = await hc.GetAsync(turnurApiURL);
+                using HttpResponseMessage response = await httpClient.GetAsync(turnurApiURL, cancellationToken).ConfigureAwait(false);
                 response.EnsureSuccessStatusCode();
-                strContent = await response.Content.ReadAsStringAsync();
+                strContent = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 
                 JsonTextReader jsr = new JsonTextReader(new StringReader(strContent));
-
-                TurnurConnections.Clear();
 
                 /*
                     new format
@@ -2879,31 +3032,41 @@ namespace SMT.EVEData
                     if(jsr.TokenType == JsonToken.StartObject)
                     {
                         JObject obj = JObject.Load(jsr);
-                        string inSignatureId = obj["in_signature"].ToString();
-                        string outSignatureId = obj["out_signature"].ToString();
-                        long solarSystemId = long.Parse(obj["in_system_id"].ToString());
-                        string wormHoleEOL = obj["expires_at"].ToString();
-                        string type = obj["signature_type"].ToString();
+                        string inSignatureId = obj["in_signature"]?.ToString();
+                        string outSignatureId = obj["out_signature"]?.ToString();
+                        string wormHoleEOL = obj["expires_at"]?.ToString();
+                        string type = obj["signature_type"]?.ToString();
 
-                        if(type != null && type == "wormhole" && solarSystemId != 0 && wormHoleEOL != null && SystemIDToName.ContainsKey(solarSystemId))
+                        if(type == "wormhole" &&
+                           long.TryParse(obj["in_system_id"]?.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out long solarSystemId) &&
+                           solarSystemId != 0 &&
+                           !string.IsNullOrEmpty(wormHoleEOL) &&
+                           SystemIDToName.ContainsKey(solarSystemId))
                         {
                             System turnurConnectionSystem = GetEveSystemFromID(solarSystemId);
 
                             TurnurConnection tc = new TurnurConnection(turnurConnectionSystem.Name, turnurConnectionSystem.Region, inSignatureId, outSignatureId, wormHoleEOL);
-                            TurnurConnections.Add(tc);
+                            refreshedConnections.Add(tc);
                         }
                     }
                 }
             }
-            catch
+            catch(OperationCanceledException) when(cancellationToken.IsCancellationRequested)
             {
                 return;
             }
-
-            if(TurnurUpdateEvent != null)
+            catch(Exception exception)
             {
-                TurnurUpdateEvent();
+                AppLog.Error("Turnur connections", exception);
+                return;
             }
+
+            RunOnUIThread(() =>
+            {
+                TurnurConnections.Clear();
+                TurnurConnections.AddRange(refreshedConnections);
+                TurnurUpdateEvent?.Invoke();
+            });
         }
 
         public void UpdateMetaliminalStorms()
@@ -2943,15 +3106,12 @@ namespace SMT.EVEData
             }
         }
 
-        public async void UpdateFactionWarfareInfo()
+        public async Task UpdateFactionWarfareInfoAsync()
         {
-            FactionWarfareSystems.Clear();
-
             try
             {
                 var esr = await EveApiClient.FactionWarfare.FactionWarSystemOwnershipAsync();
-
-                string debugListofSytems = "";
+                List<FactionWarfareSystemInfo> refreshedSystems = new List<FactionWarfareSystemInfo>();
 
                 if (ESIHelpers.ValidateESICall(esr))
                 {
@@ -2972,107 +3132,121 @@ namespace SMT.EVEData
                         fwsi.VictoryPoints = (int)i.VictoryPoints;
                         fwsi.VictoryPointsThreshold = (int)i.VictoryPointsThreshold;
 
-                        FactionWarfareSystems.Add(fwsi);
-
-                        debugListofSytems += fwsi.SystemName + "\n";
+                        refreshedSystems.Add(fwsi);
                     }
                 }
 
+                Dictionary<string, FactionWarfareSystemInfo> systemsByName = refreshedSystems
+                    .Where(system => !string.IsNullOrEmpty(system.SystemName))
+                    .ToDictionary(system => system.SystemName, StringComparer.Ordinal);
+
                 // step 1, identify all the Frontline systems, these will be systems with connections to other systems with a different occupier
-                foreach(FactionWarfareSystemInfo fws in FactionWarfareSystems)
+                foreach(FactionWarfareSystemInfo fws in refreshedSystems)
                 {
                     System s = GetEveSystemFromID(fws.SystemID);
+                    if(s == null)
+                    {
+                        continue;
+                    }
+
                     foreach(string js in s.Jumps)
                     {
-                        foreach(FactionWarfareSystemInfo fwss in FactionWarfareSystems)
+                        if(systemsByName.TryGetValue(js, out FactionWarfareSystemInfo adjacent) && adjacent.OccupierID != fws.OccupierID)
                         {
-                            if(fwss.SystemName == js && fwss.OccupierID != fws.OccupierID)
-                            {
-                                fwss.SystemState = FactionWarfareSystemInfo.State.Frontline;
-                                fws.SystemState = FactionWarfareSystemInfo.State.Frontline;
-                            }
+                            adjacent.SystemState = FactionWarfareSystemInfo.State.Frontline;
+                            fws.SystemState = FactionWarfareSystemInfo.State.Frontline;
                         }
                     }
                 }
 
-                // step 2, itendify all commandline operations by flooding out one from the frontlines
-                foreach(FactionWarfareSystemInfo fws in FactionWarfareSystems)
+                // Step 2: identify command-line operations adjacent to the front lines.
+                foreach(FactionWarfareSystemInfo fws in refreshedSystems)
                 {
                     if(fws.SystemState == FactionWarfareSystemInfo.State.Frontline)
                     {
                         System s = GetEveSystemFromID(fws.SystemID);
+                        if(s == null)
+                        {
+                            continue;
+                        }
 
                         foreach(string js in s.Jumps)
                         {
-                            foreach(FactionWarfareSystemInfo fwss in FactionWarfareSystems)
+                            if(systemsByName.TryGetValue(js, out FactionWarfareSystemInfo adjacent) &&
+                               adjacent.SystemState == FactionWarfareSystemInfo.State.None &&
+                               adjacent.OccupierID == fws.OccupierID)
                             {
-                                if(fwss.SystemName == js && fwss.SystemState == FactionWarfareSystemInfo.State.None && fwss.OccupierID == fws.OccupierID)
-                                {
-                                    fwss.SystemState = FactionWarfareSystemInfo.State.CommandLineOperation;
-                                    fwss.LinkSystemID = fws.SystemID;
-                                }
+                                adjacent.SystemState = FactionWarfareSystemInfo.State.CommandLineOperation;
+                                adjacent.LinkSystemID = fws.SystemID;
                             }
                         }
                     }
                 }
 
-                // step 3, itendify all Rearguard operations by flooding out one from the command lines
-                foreach(FactionWarfareSystemInfo fws in FactionWarfareSystems)
+                // Step 3: identify rearguard operations adjacent to command-line systems.
+                foreach(FactionWarfareSystemInfo fws in refreshedSystems)
                 {
                     if(fws.SystemState == FactionWarfareSystemInfo.State.CommandLineOperation)
                     {
                         System s = GetEveSystemFromID(fws.SystemID);
+                        if(s == null)
+                        {
+                            continue;
+                        }
 
                         foreach(string js in s.Jumps)
                         {
-                            foreach(FactionWarfareSystemInfo fwss in FactionWarfareSystems)
+                            if(systemsByName.TryGetValue(js, out FactionWarfareSystemInfo adjacent) &&
+                               adjacent.SystemState == FactionWarfareSystemInfo.State.None &&
+                               adjacent.OccupierID == fws.OccupierID)
                             {
-                                if(fwss.SystemName == js && fwss.SystemState == FactionWarfareSystemInfo.State.None && fwss.OccupierID == fws.OccupierID)
-                                {
-                                    fwss.SystemState = FactionWarfareSystemInfo.State.Rearguard;
-                                    fwss.LinkSystemID = fws.SystemID;
-                                }
+                                adjacent.SystemState = FactionWarfareSystemInfo.State.Rearguard;
+                                adjacent.LinkSystemID = fws.SystemID;
                             }
                         }
                     }
                 }
 
-                // for ease remove all "none" systems
-                //FactionWarfareSystems.RemoveAll(sys => sys.SystemState == FactionWarfareSystemInfo.State.None);
+                RunOnUIThread(() =>
+                {
+                    FactionWarfareSystems.Clear();
+                    FactionWarfareSystems.AddRange(refreshedSystems);
+                });
             }
-            catch { }
+            catch(Exception exception)
+            {
+                AppLog.Error("Faction warfare update", exception);
+            }
         }
 
-        public void AddUpdateJumpBridge(string from, string to, long stationID)
+        public JumpBridge AddUpdateJumpBridge(string from, string to, long stationID)
         {
             // validate
             if(GetEveSystem(from) == null || GetEveSystem(to) == null)
             {
-                return;
+                return null;
             }
-
-            bool found = false;
 
             foreach(JumpBridge jb in JumpBridges)
             {
                 if(jb.From == from)
                 {
-                    found = true;
                     jb.FromID = stationID;
+                    return jb;
                 }
                 if(jb.To == from)
                 {
-                    found = true;
                     jb.ToID = stationID;
+                    return jb;
                 }
             }
 
-            if(!found)
+            JumpBridge newJumpBridge = new JumpBridge(from, to)
             {
-                JumpBridge njb = new JumpBridge(from, to);
-                njb.FromID = stationID;
-                JumpBridges.Add(njb);
-            }
+                FromID = stationID,
+            };
+            JumpBridges.Add(newJumpBridge);
+            return newJumpBridge;
         }
 
         /// <summary>
@@ -3118,7 +3292,7 @@ namespace SMT.EVEData
             InitFactionWarfareInfo();
             InitPOI();
 
-            ActiveSovCampaigns = new List<SOVCampaign>();
+            ActiveSovCampaigns = new ObservableCollection<SOVCampaign>();
 
             // Auto-load infrastructure upgrades if file exists
             string upgradesFile = Path.Combine(SaveDataRootFolder, "InfrastructureUpgrades.txt");
@@ -3129,7 +3303,7 @@ namespace SMT.EVEData
 
             InitZKillFeed();
 
-            StartBackgroundThread();
+            StartBackgroundUpdates();
         }
 
         private void InitPOI()
@@ -3174,8 +3348,9 @@ namespace SMT.EVEData
                     }
                 }
             }
-            catch
+            catch(Exception exception)
             {
+                AppLog.Error("Load points of interest", exception);
             }
         }
 
@@ -3185,7 +3360,6 @@ namespace SMT.EVEData
         private void InitTheraConnections()
         {
             TheraConnections = new List<TheraConnection>();
-            UpdateTheraConnections();
         }
 
         /// <summary>
@@ -3194,7 +3368,6 @@ namespace SMT.EVEData
         private void InitTurnurConnections()
         {
             TurnurConnections = new List<TurnurConnection>();
-            UpdateTurnurConnections();
         }
 
         /// <summary>
@@ -3222,7 +3395,6 @@ namespace SMT.EVEData
         private void InitFactionWarfareInfo()
         {
             FactionWarfareSystems = new List<FactionWarfareSystemInfo>();
-            UpdateFactionWarfareInfo();
         }
 
         /// <summary>
@@ -3238,6 +3410,14 @@ namespace SMT.EVEData
         /// Intel File watcher changed handler
         /// </summary>
         private void IntelFileWatcher_Changed(object sender, FileSystemEventArgs e)
+        {
+            lock(intelLogLock)
+            {
+                ProcessIntelFileChange(e);
+            }
+        }
+
+        private void ProcessIntelFileChange(FileSystemEventArgs e)
         {
             string changedFile = e.FullPath;
 
@@ -3391,7 +3571,7 @@ namespace SMT.EVEData
                             {
                                 foreach(EVEData.IntelData idl in IntelDataList)
                                 {
-                                    if(idl.IntelString == newIntelString && (DateTime.Now - idl.IntelTime).Seconds < 5)
+                                    if(idl.IntelString == newIntelString && (DateTime.Now - idl.IntelTime).TotalSeconds < 5)
                                     {
                                         addToIntel = false;
                                         break;
@@ -3459,8 +3639,12 @@ namespace SMT.EVEData
 
                     intelFileReadPos[changedFile] = fileReadFrom;
                 }
-                catch
+                catch(IOException)
                 {
+                }
+                catch(Exception exception)
+                {
+                    AppLog.Error("Parse intel log", exception);
                 }
             }
             else
@@ -3472,6 +3656,14 @@ namespace SMT.EVEData
         /// GameLog File watcher changed handler
         /// </summary>
         private void GameLogFileWatcher_Changed(object sender, FileSystemEventArgs e)
+        {
+            lock(gameLogLock)
+            {
+                ProcessGameLogFileChange(e);
+            }
+        }
+
+        private void ProcessGameLogFileChange(FileSystemEventArgs e)
         {
             string changedFile = e.FullPath;
             string characterName = string.Empty;
@@ -3628,8 +3820,9 @@ namespace SMT.EVEData
 
                 gameFileReadPos[changedFile] = fileReadFrom;
             }
-            catch
+            catch(Exception exception)
             {
+                AppLog.Error("Parse game log", exception);
             }
         }
 
@@ -3663,86 +3856,107 @@ namespace SMT.EVEData
                     AddCharacter(c);
                 }
             }
-            catch
+            catch(Exception exception)
             {
+                AppLog.Error("Load characters", exception);
             }
         }
 
         /// <summary>
-        /// Start the Low Frequency Update Thread
+        /// Start the tracked background update task.
         /// </summary>
-        private void StartBackgroundThread()
+        private void StartBackgroundUpdates()
         {
-            new Thread(async () =>
+            if(!backgroundUpdateTask.IsCompleted)
             {
-                Thread.CurrentThread.IsBackground = true;
+                return;
+            }
 
-
-                // split the intial requests into 3 for a better initialisation
-
-                foreach(LocalCharacter c in GetLocalCharactersCopy())
-                {
-                    await c.RefreshAccessToken().ConfigureAwait(true);
-                }
-
-                foreach(LocalCharacter c in GetLocalCharactersCopy())
-                {
-                    await c.UpdatePositionFromESI().ConfigureAwait(true);
-                }
-
-                foreach(LocalCharacter c in GetLocalCharactersCopy())
-                {
-                    await c.UpdateInfoFromESI().ConfigureAwait(true);
-                }
-
-
-
-
-                // loop forever
-                while(BackgroundThreadShouldTerminate == false)
-                {
-                    // character Update
-                    if((NextCharacterUpdate - DateTime.Now).Ticks < 0)
-                    {
-                        NextCharacterUpdate = DateTime.Now + CharacterUpdateRate;
-
-                        var characters = GetLocalCharactersCopy();
-                        for(int i = 0; i < characters.Count; i++)
-                        {
-                            LocalCharacter c = characters[i];
-                            await c.Update();
-                        }
-                    }
-
-                    // sov update
-                    if((NextSOVCampaignUpdate - DateTime.Now).Ticks < 0)
-                    {
-                        NextSOVCampaignUpdate = DateTime.Now + SOVCampaignUpdateRate;
-                        UpdateSovCampaigns();
-                    }
-
-                    // low frequency update
-                    if((NextLowFreqUpdate - DateTime.Now).Minutes < 0)
-                    {
-                        NextLowFreqUpdate = DateTime.Now + LowFreqUpdateRate;
-
-                        UpdateESIUniverseData();
-                        UpdateServerInfo();
-                        UpdateTheraConnections();
-                        UpdateTurnurConnections();
-                    }
-
-                    if((NextDotlanUpdate - DateTime.Now).Minutes < 0)
-                    {
-                        UpdateDotlanKillDeltaInfo();
-                    }
-
-                    Thread.Sleep(100);
-                }
-            }).Start();
+            backgroundUpdateTask = Task.Run(() => BackgroundUpdateLoopAsync(backgroundCancellation.Token));
         }
 
-        private async void UpdateDotlanKillDeltaInfo()
+        private async Task BackgroundUpdateLoopAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                // Split the initial requests for a responsive startup and predictable API usage.
+                foreach(LocalCharacter character in GetLocalCharactersCopy())
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await character.RefreshAccessToken().ConfigureAwait(false);
+                }
+
+                foreach(LocalCharacter character in GetLocalCharactersCopy())
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await character.UpdatePositionFromESI().ConfigureAwait(false);
+                }
+
+                foreach(LocalCharacter character in GetLocalCharactersCopy())
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await character.UpdateInfoFromESI().ConfigureAwait(false);
+                }
+
+                while(!cancellationToken.IsCancellationRequested)
+                {
+                    try
+                    {
+                        DateTime now = DateTime.Now;
+
+                        if(now >= NextCharacterUpdate)
+                        {
+                            NextCharacterUpdate = now + CharacterUpdateRate;
+                            foreach(LocalCharacter character in GetLocalCharactersCopy())
+                            {
+                                cancellationToken.ThrowIfCancellationRequested();
+                                await character.Update().ConfigureAwait(false);
+                            }
+                        }
+
+                        if(now >= NextSOVCampaignUpdate)
+                        {
+                            NextSOVCampaignUpdate = now + SOVCampaignUpdateRate;
+                            await UpdateSovCampaignsAsync().ConfigureAwait(false);
+                        }
+
+                        if(now >= NextLowFreqUpdate)
+                        {
+                            NextLowFreqUpdate = now + LowFreqUpdateRate;
+                            await UpdateESIUniverseDataAsync(cancellationToken).ConfigureAwait(false);
+                            await UpdateServerInfoAsync().ConfigureAwait(false);
+                            await UpdateTheraConnectionsAsync(cancellationToken).ConfigureAwait(false);
+                            await UpdateTurnurConnectionsAsync(cancellationToken).ConfigureAwait(false);
+                            await UpdateFactionWarfareInfoAsync().ConfigureAwait(false);
+                        }
+
+                        if(now >= NextDotlanUpdate)
+                        {
+                            await UpdateDotlanKillDeltaInfoAsync(cancellationToken).ConfigureAwait(false);
+                        }
+                    }
+                    catch(OperationCanceledException) when(cancellationToken.IsCancellationRequested)
+                    {
+                        break;
+                    }
+                    catch(Exception exception)
+                    {
+                        AppLog.Error("Background updates", exception);
+                    }
+
+                    await Task.Delay(TimeSpan.FromMilliseconds(100), cancellationToken).ConfigureAwait(false);
+                }
+            }
+            catch(OperationCanceledException) when(cancellationToken.IsCancellationRequested)
+            {
+            }
+            catch(Exception exception)
+            {
+                AppLog.Error("Background update loop", exception);
+            }
+        }
+
+        private async Task UpdateDotlanKillDeltaInfoAsync(CancellationToken cancellationToken)
         {
             // set the update for 20 minutes from now initially which will be pushed further once we have the last-modified
             // however if the request fails we still push out the request..
@@ -3752,23 +3966,21 @@ namespace SMT.EVEData
             {
                 string dotlanNPCDeltaAPIurl = "https://evemaps.dotlan.net/ajax/npcdelta";
 
-                HttpClient hc = new HttpClient();
-                string versionNum = VersionStr.Split("_")[1];
-
                 string userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36 Edg/145.0.0.0";
-                hc.DefaultRequestHeaders.Add("User-Agent", userAgent);
+                using HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, dotlanNPCDeltaAPIurl);
+                request.Headers.TryAddWithoutValidation("User-Agent", userAgent);
                 if(LastDotlanUpdate != DateTime.MinValue)
                 {
-                    hc.DefaultRequestHeaders.IfModifiedSince = LastDotlanUpdate;
+                    request.Headers.IfModifiedSince = LastDotlanUpdate;
                 }
 
                 // set the etag if we have one
                 if(LastDotlanETAG != "")
                 {
-                    hc.DefaultRequestHeaders.IfNoneMatch.Add(new EntityTagHeaderValue(LastDotlanETAG));
+                    request.Headers.IfNoneMatch.Add(new EntityTagHeaderValue(LastDotlanETAG));
                 }
 
-                var response = await hc.GetAsync(dotlanNPCDeltaAPIurl);
+                using HttpResponseMessage response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
                 // update the next request to the last modified + 1hr + random offset
                 if(response.Content.Headers.LastModified.HasValue)
@@ -3794,16 +4006,19 @@ namespace SMT.EVEData
                 {
                     // read the data
                     string strContent = string.Empty;
-                    strContent = await response.Content.ReadAsStringAsync();
+                    response.EnsureSuccessStatusCode();
+                    strContent = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 
                     // parse the json response into kvp string/strings (system id)/(delta)
                     Dictionary<string, string> killdDeltadata = JsonConvert.DeserializeObject<Dictionary<string, string>>(strContent);
 
-                    foreach(var kvp in killdDeltadata)
+                    foreach(var kvp in killdDeltadata ?? new Dictionary<string, string>())
                     {
-                        Console.WriteLine($"Key: {kvp.Key}, Value: {kvp.Value}");
-                        int systemId = int.Parse(kvp.Key);
-                        int killDelta = int.Parse(kvp.Value);
+                        if(!int.TryParse(kvp.Key, NumberStyles.Integer, CultureInfo.InvariantCulture, out int systemId) ||
+                           !int.TryParse(kvp.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int killDelta))
+                        {
+                            continue;
+                        }
 
                         System s = GetEveSystemFromID(systemId);
                         if(s != null)
@@ -3813,15 +4028,19 @@ namespace SMT.EVEData
                     }
                 }
             }
-            catch
+            catch(OperationCanceledException) when(cancellationToken.IsCancellationRequested)
             {
+            }
+            catch(Exception exception)
+            {
+                AppLog.Error("Dotlan update", exception);
             }
         }
 
         /// <summary>
         /// Start the ESI download for the Jump info
         /// </summary>
-        private async void UpdateIncursionsFromESI()
+        private async Task UpdateIncursionsFromESIAsync()
         {
             try
             {
@@ -3841,15 +4060,16 @@ namespace SMT.EVEData
                     }
                 }
             }
-            catch
+            catch(Exception exception)
             {
+                AppLog.Error("Incursion update", exception);
             }
         }
 
         /// <summary>
         /// Start the ESI download for the Jump info
         /// </summary>
-        private async void UpdateJumpsFromESI()
+        private async Task UpdateJumpsFromESIAsync()
         {
             try
             {
@@ -3866,15 +4086,16 @@ namespace SMT.EVEData
                     }
                 }
             }
-            catch
+            catch(Exception exception)
             {
+                AppLog.Error("System jump update", exception);
             }
         }
 
         /// <summary>
         /// Start the ESI download for the kill info
         /// </summary>
-        private async void UpdateKillsFromESI()
+        private async Task UpdateKillsFromESIAsync()
         {
             try
             {
@@ -3893,153 +4114,129 @@ namespace SMT.EVEData
                     }
                 }
             }
-            catch
+            catch(Exception exception)
             {
+                AppLog.Error("System kill update", exception);
             }
         }
 
-        private async void UpdateSovCampaigns()
+        private async Task UpdateSovCampaignsAsync()
         {
             try
             {
-                bool sendUpdateEvent = false;
-
-                foreach(SOVCampaign sc in ActiveSovCampaigns)
+                var esr = await EveApiClient.Sovereignty.ListSovereigntyCampaignsAsync();
+                if(!ESIHelpers.ValidateESICall(esr))
                 {
-                    sc.Valid = false;
+                    return;
                 }
 
-                List<int> allianceIDsToResolve = new List<int>();
+                List<SOVCampaign> refreshedCampaigns = new List<SOVCampaign>();
+                HashSet<int> allianceIDsToResolve = new HashSet<int>();
+                DateTime now = DateTime.UtcNow;
 
-                var esr = await EveApiClient.Sovereignty.ListSovereigntyCampaignsAsync();
-                if (ESIHelpers.ValidateESICall(esr))
+                foreach(SovereigntyCampaign campaign in esr.Model)
                 {
-                    foreach (SovereigntyCampaign c in esr.Model)
+                    System system = GetEveSystemFromID(campaign.SolarSystemId);
+                    if(system == null)
                     {
-                        SOVCampaign ss = null;
-
-                        foreach(SOVCampaign asc in ActiveSovCampaigns)
-                        {
-                            if(asc.CampaignID == c.CampaignId)
-                            {
-                                ss = asc;
-                            }
-                        }
-
-                        if (ss == null)
-                        {
-                            System sys = GetEveSystemFromID(c.SolarSystemId);
-                            if (sys == null)
-                            {
-                                continue;
-                            }
-
-                            ss = new SOVCampaign
-                            {
-                                CampaignID = (int)c.CampaignId,
-                                DefendingAllianceID = (int)(c.DefenderId ?? 0),
-                                System = sys.Name,
-                                Region = sys.Region,
-                                StartTime = c.StartTime,
-                                DefendingAllianceName = "",
-                            };
-
-                            if(c.EventType == "ihub_defense")
-                            {
-                                ss.Type = "IHub";
-                            }
-
-                            if(c.EventType == "tcu_defense")
-                            {
-                                ss.Type = "TCU";
-                            }
-
-                            ActiveSovCampaigns.Add(ss);
-                            sendUpdateEvent = true;
-                        }
-
-                        if (ss.AttackersScore != (c.AttackersScore ?? 0) || ss.DefendersScore != (c.DefenderScore ?? 0))
-                        {
-                            sendUpdateEvent = true;
-                        }
-
-                        ss.AttackersScore = c.AttackersScore ?? 0;
-                        ss.DefendersScore = c.DefenderScore ?? 0;
-                        ss.Valid = true;
-
-                        if(AllianceIDToName.ContainsKey(ss.DefendingAllianceID))
-                        {
-                            ss.DefendingAllianceName = AllianceIDToName[ss.DefendingAllianceID];
-                        }
-                        else
-                        {
-                            if(!allianceIDsToResolve.Contains(ss.DefendingAllianceID))
-                            {
-                                allianceIDsToResolve.Add(ss.DefendingAllianceID);
-                            }
-                        }
-
-                        int NodesToWin = (int)Math.Ceiling(ss.DefendersScore / 0.07);
-                        int NodesToDefend = (int)Math.Ceiling(ss.AttackersScore / 0.07);
-                        ss.State = $"Nodes Remaining\nAttackers : {NodesToWin}\nDefenders : {NodesToDefend}";
-
-                        ss.TimeToStart = ss.StartTime - DateTime.UtcNow;
-
-                        if(ss.StartTime < DateTime.UtcNow)
-                        {
-                            ss.IsActive = true;
-                        }
-                        else
-                        {
-                            ss.IsActive = false;
-                        }
+                        continue;
                     }
+
+                    int allianceID = (int)(campaign.DefenderId ?? 0);
+                    double attackersScore = campaign.AttackersScore ?? 0;
+                    double defendersScore = campaign.DefenderScore ?? 0;
+                    int nodesToWin = (int)Math.Ceiling(defendersScore / 0.07);
+                    int nodesToDefend = (int)Math.Ceiling(attackersScore / 0.07);
+
+                    SOVCampaign refreshed = new SOVCampaign
+                    {
+                        CampaignID = (int)campaign.CampaignId,
+                        DefendingAllianceID = allianceID,
+                        DefendingAllianceName = GetAllianceName(allianceID),
+                        System = system.Name,
+                        Region = system.Region,
+                        StartTime = campaign.StartTime,
+                        Type = campaign.EventType == "ihub_defense" ? "IHub" : campaign.EventType == "tcu_defense" ? "TCU" : campaign.EventType,
+                        AttackersScore = attackersScore,
+                        DefendersScore = defendersScore,
+                        State = $"Nodes Remaining\nAttackers : {nodesToWin}\nDefenders : {nodesToDefend}",
+                        TimeToStart = campaign.StartTime - now,
+                        IsActive = campaign.StartTime < now,
+                        Valid = true,
+                    };
+
+                    if(allianceID != 0 && string.IsNullOrEmpty(refreshed.DefendingAllianceName))
+                    {
+                        allianceIDsToResolve.Add(allianceID);
+                    }
+
+                    refreshedCampaigns.Add(refreshed);
                 }
 
                 if(allianceIDsToResolve.Count > 0)
                 {
-                    await ResolveAllianceIDs(allianceIDsToResolve);
+                    await ResolveAllianceIDs(allianceIDsToResolve.ToList()).ConfigureAwait(false);
                 }
 
-                foreach(SOVCampaign sc in ActiveSovCampaigns.ToList())
+                foreach(SOVCampaign campaign in refreshedCampaigns)
                 {
-                    if(string.IsNullOrEmpty(sc.DefendingAllianceName) && AllianceIDToName.ContainsKey(sc.DefendingAllianceID))
-                    {
-                        sc.DefendingAllianceName = AllianceIDToName[sc.DefendingAllianceID];
-                    }
-
-                    if(sc.Valid == false)
-                    {
-                        ActiveSovCampaigns.Remove(sc);
-                        sendUpdateEvent = true;
-                    }
+                    campaign.DefendingAllianceName = GetAllianceName(campaign.DefendingAllianceID);
                 }
 
-                if(sendUpdateEvent)
+                RunOnUIThread(() => ApplySovCampaigns(refreshedCampaigns));
+            }
+            catch(Exception exception)
+            {
+                AppLog.Error("Sovereignty campaigns", exception);
+            }
+        }
+
+        private void ApplySovCampaigns(List<SOVCampaign> refreshedCampaigns)
+        {
+            Dictionary<int, SOVCampaign> refreshedByID = refreshedCampaigns.ToDictionary(campaign => campaign.CampaignID);
+            bool collectionChanged = false;
+
+            foreach(SOVCampaign existing in ActiveSovCampaigns.ToList())
+            {
+                if(!refreshedByID.ContainsKey(existing.CampaignID))
                 {
-                    if(SovUpdateEvent != null)
-                    {
-                        SovUpdateEvent();
-                    }
+                    ActiveSovCampaigns.Remove(existing);
+                    collectionChanged = true;
                 }
             }
-            catch { }
+
+            Dictionary<int, SOVCampaign> existingByID = ActiveSovCampaigns.ToDictionary(campaign => campaign.CampaignID);
+            foreach(SOVCampaign refreshed in refreshedCampaigns)
+            {
+                if(!existingByID.TryGetValue(refreshed.CampaignID, out SOVCampaign existing))
+                {
+                    ActiveSovCampaigns.Add(refreshed);
+                    collectionChanged = true;
+                    continue;
+                }
+
+                existing.UpdateFrom(refreshed);
+            }
+
+            if(collectionChanged)
+            {
+                SovUpdateEvent?.Invoke();
+            }
         }
 
         /// <summary>
         /// Start the ESI download for the kill info
         /// </summary>
-        private async void UpdateSOVFromESI()
+        private async Task UpdateSOVFromESIAsync(CancellationToken cancellationToken)
         {
             string url = @"https://esi.evetech.net/v1/sovereignty/map/?datasource=tranquility";
             string strContent = string.Empty;
 
             try
             {
-                HttpClient hc = new HttpClient();
-                var response = await hc.GetAsync(url);
+                using HttpResponseMessage response = await httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
                 response.EnsureSuccessStatusCode();
-                strContent = await response.Content.ReadAsStringAsync();
+                strContent = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
                 JsonTextReader jsr = new JsonTextReader(new StringReader(strContent));
 
                 // JSON feed is now in the format : [{ "system_id": 30035042,  and then optionally alliance_id, corporation_id and corporation_id, faction_id },
@@ -4048,28 +4245,35 @@ namespace SMT.EVEData
                     if(jsr.TokenType == JsonToken.StartObject)
                     {
                         JObject obj = JObject.Load(jsr);
-                        long systemID = long.Parse(obj["system_id"].ToString());
+                        if(!long.TryParse(obj["system_id"]?.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out long systemID))
+                        {
+                            continue;
+                        }
 
                         if(SystemIDToName.ContainsKey(systemID))
                         {
                             System es = GetEveSystem(SystemIDToName[systemID]);
                             if(es != null)
                             {
-                                if(obj["alliance_id"] != null)
+                                if(int.TryParse(obj["alliance_id"]?.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out int allianceID))
                                 {
-                                    es.SOVAllianceID = int.Parse(obj["alliance_id"].ToString());
+                                    es.SOVAllianceID = allianceID;
                                 }
                             }
                         }
                     }
                 }
             }
-            catch
+            catch(OperationCanceledException) when(cancellationToken.IsCancellationRequested)
             {
+            }
+            catch(Exception exception)
+            {
+                AppLog.Error("Sovereignty map", exception);
             }
         }
 
-        private async void UpdateSovStructureUpdate()
+        private async Task UpdateSovStructureUpdateAsync()
         {
             try
             {
@@ -4115,13 +4319,16 @@ namespace SMT.EVEData
                     }
                 }
             }
-            catch { }
+            catch(Exception exception)
+            {
+                AppLog.Error("Sovereignty structures", exception);
+            }
         }
 
         /// <summary>
         /// Start the download for the Server Info
         /// </summary>
-        private async void UpdateServerInfo()
+        private async Task UpdateServerInfoAsync()
         {
             try
             {
@@ -4140,7 +4347,10 @@ namespace SMT.EVEData
                     ServerInfo.ServerVersion = "";
                 }
             }
-            catch { }
+            catch(Exception exception)
+            {
+                AppLog.Error("Server status", exception);
+            }
         }
 
 

--- a/EVEData/JumpRoute.cs
+++ b/EVEData/JumpRoute.cs
@@ -72,19 +72,22 @@
                     {
                         for (int j = 2; j < sysList.Count; j++)
                         {
-                            List<string> a = Navigation.GetSystemsWithinXLYFrom(CurrentRoute[j - 2].SystemName, MaxLY, false, false);
-                            List<string> b = Navigation.GetSystemsWithinXLYFrom(CurrentRoute[j].SystemName, MaxLY, false, false);
+                            List<string> a = Navigation.GetSystemsWithinXLYFrom(sysList[j - 2].SystemName, actualMaxLY, false, false);
+                            List<string> b = Navigation.GetSystemsWithinXLYFrom(sysList[j].SystemName, actualMaxLY, false, false);
 
-                            IEnumerable<string> alternatives = a.AsQueryable().Intersect(b);
+                            IEnumerable<string> alternatives = a.Intersect(b);
+                            string currentMid = sysList[j - 1].SystemName;
+                            List<string> alternateMids = new List<string>();
 
-                            AlternateMids[CurrentRoute[j - 1].SystemName] = new List<string>();
                             foreach (string mid in alternatives)
                             {
-                                if (mid != CurrentRoute[j - 1].SystemName)
+                                if (mid != currentMid)
                                 {
-                                    AlternateMids[CurrentRoute[j - 1].SystemName].Add(mid);
+                                    alternateMids.Add(mid);
                                 }
                             }
+
+                            AlternateMids[currentMid] = alternateMids;
                         }
                     }
                 }

--- a/EVEData/JumpRoute.cs
+++ b/EVEData/JumpRoute.cs
@@ -2,29 +2,36 @@
 {
     public class JumpRoute
     {
-        public List<Navigation.RoutePoint> CurrentRoute { get; set; }
-        public List<string> WayPoints { get; set; }
+        public global::System.Collections.ObjectModel.ObservableCollection<Navigation.RoutePoint> CurrentRoute { get; set; }
+        public global::System.Collections.ObjectModel.ObservableCollection<string> WayPoints { get; set; }
         public double MaxLY { get; set; }
         public int JDC { get; set; }
 
-        public List<string> AvoidSystems { get; set; }
+        public global::System.Collections.ObjectModel.ObservableCollection<string> AvoidSystems { get; set; }
 
         public Dictionary<string, List<string>> AlternateMids { get; set; }
+        public string FailedSegment { get; private set; }
+        public int JumpCount => Math.Max(0, CurrentRoute.Count - 1);
+        public int MidCount => Math.Max(0, CurrentRoute.Count - WayPoints.Count);
+        public decimal TotalDistance => CurrentRoute.Sum(routePoint => routePoint.LY);
 
         public JumpRoute()
         {
             MaxLY = 7.0;
             JDC = 5;
 
-            CurrentRoute = new List<Navigation.RoutePoint>();
-            WayPoints = new List<string>();
-            AvoidSystems = new List<string>();
+            CurrentRoute = new global::System.Collections.ObjectModel.ObservableCollection<Navigation.RoutePoint>();
+            WayPoints = new global::System.Collections.ObjectModel.ObservableCollection<string>();
+            AvoidSystems = new global::System.Collections.ObjectModel.ObservableCollection<string>();
             AlternateMids = new Dictionary<string, List<string>>();
+            FailedSegment = string.Empty;
         }
 
         public void Recalculate()
         {
             CurrentRoute.Clear();
+            AlternateMids.Clear();
+            FailedSegment = string.Empty;
 
             if (WayPoints.Count < 2)
             {
@@ -41,9 +48,7 @@
             string start = string.Empty;
             string end = WayPoints[0];
 
-            List<string> avoidSystems = AvoidSystems;
-
-            AlternateMids.Clear();
+            List<string> avoidSystems = AvoidSystems.ToList();
 
             // loop through all the waypoints
             for (int i = 1; i < WayPoints.Count; i++)
@@ -52,6 +57,14 @@
                 end = WayPoints[i];
 
                 List<Navigation.RoutePoint> sysList = Navigation.NavigateCapitals(start, end, actualMaxLY, null, avoidSystems);
+
+                if(sysList == null || sysList.Count == 0)
+                {
+                    CurrentRoute.Clear();
+                    AlternateMids.Clear();
+                    FailedSegment = $"{start} → {end}";
+                    return;
+                }
 
                 if (sysList != null)
                 {

--- a/EVEData/LocalCharacter.cs
+++ b/EVEData/LocalCharacter.cs
@@ -537,49 +537,48 @@ namespace SMT.EVEData
                 return jbl;
 
             await UpdateLock.WaitAsync();
+            try
             {
                 AuthDTO auth = GetAuthDTO();
                 if (auth == null)
                 {
-                    UpdateLock.Release();
                     return jbl;
                 }
 
-                try
+                var esr = await EveManager.Instance.EveApiClient.Search.SearchCharacterAsync(auth, new List<string> { "structure" }, JumpBridgeFilterString);
+                if (!ESIHelpers.ValidateESICall(esr) || esr.Model == null)
                 {
-                    var esr = await EveManager.Instance.EveApiClient.Search.SearchCharacterAsync(auth, new List<string> { "structure" }, JumpBridgeFilterString);
-                    if (!ESIHelpers.ValidateESICall(esr) || esr.Model == null)
+                    return jbl;
+                }
+
+                List<long> structureIds = esr.Model.Structure ?? new List<long>();
+                foreach (long stationID in structureIds)
+                {
+                    var esrs = await EveManager.Instance.EveApiClient.Universe.GetStructureInfoAsync(auth, stationID);
+                    if (ESIHelpers.ValidateESICall(esrs) && esrs.Model != null && esrs.Model.TypeId == 35841)
                     {
-                        UpdateLock.Release();
-                        return jbl;
+                        string[] parts = (esrs.Model.Name ?? string.Empty).Split(' ');
+                        if (parts.Length >= 3)
+                        {
+                            JumpBridge jumpBridge = new JumpBridge(parts[0], parts[2])
+                            {
+                                FromID = stationID,
+                            };
+                            jbl.Add(jumpBridge);
+                        }
                     }
 
-                    List<long> structureIds = esr.Model.Structure ?? new List<long>();
-                    foreach (long stationID in structureIds)
-                    {
-                        var esrs = await EveManager.Instance.EveApiClient.Universe.GetStructureInfoAsync(auth, stationID);
-                        if (ESIHelpers.ValidateESICall(esrs) && esrs.Model != null)
-                        {
-                            if (esrs.Model.TypeId == 35841)
-                            {
-                                string[] parts = (esrs.Model.Name ?? string.Empty).Split(' ');
-                                if (parts.Length >= 3)
-                                {
-                                    string from = parts[0];
-                                    string to = parts[2];
-                                    EveManager.Instance.AddUpdateJumpBridge(from, to, stationID);
-                                }
-                            }
-                        }
-                        Thread.Sleep(100);
-                    }
-                }
-                catch
-                {
-                    // ESI-Search failed
+                    await Task.Delay(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false);
                 }
             }
-            UpdateLock.Release();
+            catch(Exception exception)
+            {
+                EVEDataUtils.AppLog.Error($"Find jump gates for {Name}", exception);
+            }
+            finally
+            {
+                UpdateLock.Release();
+            }
 
             return jbl;
         }
@@ -684,10 +683,10 @@ namespace SMT.EVEData
         public async Task Update()
         {
             await UpdateLock.WaitAsync();
+            try
             {
-
                 TimeSpan ts = ESIAccessTokenExpiry - DateTime.Now;
-                if (ts.Minutes < 1)
+                if (ts.TotalMinutes < 1)
                 {
                     await RefreshAccessToken().ConfigureAwait(false);
                     await UpdateInfoFromESI().ConfigureAwait(false);
@@ -712,7 +711,7 @@ namespace SMT.EVEData
                 if (routeNeedsUpdate)
                 {
                     routeNeedsUpdate = false;
-                    UpdateActiveRoute();
+                    await UpdateActiveRoute().ConfigureAwait(false);
 
                     if (RouteUpdatedEvent != null)
                     {
@@ -726,7 +725,10 @@ namespace SMT.EVEData
                     UpdateWarningSystems();
                 }
             }
-            UpdateLock.Release();
+            finally
+            {
+                UpdateLock.Release();
+            }
         }
 
         protected void OnPropertyChanged(string name)
@@ -754,7 +756,7 @@ namespace SMT.EVEData
                 if (tokenDetails == null || string.IsNullOrEmpty(tokenDetails.AccessToken))
                 {
                     ssoErrorCount++;
-                    Thread.Sleep(20000);
+                    await Task.Delay(TimeSpan.FromSeconds(20)).ConfigureAwait(false);
                     if (ssoErrorCount > 50)
                     {
                         ESIRefreshToken = "";
@@ -783,13 +785,14 @@ namespace SMT.EVEData
                     ESIRefreshToken = "";
                     ESILinked = false;
                 }
+                EVEDataUtils.AppLog.Error($"Refresh ESI token for {Name}", ex);
             }
         }
 
         /// <summary>
         /// Update the active route for the character
         /// </summary>
-        private async void UpdateActiveRoute()
+        private async Task UpdateActiveRoute()
         {
             if (esiSendRouteClear)
             {
@@ -875,70 +878,89 @@ namespace SMT.EVEData
             {
                 esiRouteNeedsUpdate = false;
                 esiRouteUpdating = true;
-
-                List<long> WayPointsToAdd = new List<long>();
-
-                lock (ActiveRouteLock)
+                try
                 {
-                    foreach (Navigation.RoutePoint rp in ActiveRoute)
+                    List<long> WayPointsToAdd = new List<long>();
+
+                    lock (ActiveRouteLock)
                     {
-                        // explicitly add interim waypoints for ansiblex gates or actual waypoints
-                        if (
-                                rp.GateToTake == Navigation.GateType.Ansiblex ||
-                                rp.GateToTake == Navigation.GateType.Thera ||
-                                rp.GateToTake == Navigation.GateType.Turnur ||
-                                rp.GateToTake == Navigation.GateType.Zarzakh ||
-                                Waypoints.Contains(rp.SystemName)
-                            )
+                        foreach (Navigation.RoutePoint rp in ActiveRoute)
                         {
-                            long wayPointSysID = EveManager.Instance.GetEveSystem(rp.SystemName).ID;
-
-                            if (rp.GateToTake == Navigation.GateType.Ansiblex)
+                            // explicitly add interim waypoints for special connections or actual waypoints
+                            if (
+                                    rp.GateToTake == Navigation.GateType.Ansiblex ||
+                                    rp.GateToTake == Navigation.GateType.Thera ||
+                                    rp.GateToTake == Navigation.GateType.Turnur ||
+                                    rp.GateToTake == Navigation.GateType.Zarzakh ||
+                                    Waypoints.Contains(rp.SystemName)
+                                )
                             {
-                                foreach (JumpBridge jb in EveManager.Instance.JumpBridges)
+                                System waypointSystem = EveManager.Instance.GetEveSystem(rp.SystemName);
+                                if(waypointSystem == null)
                                 {
-                                    if (jb.From == rp.SystemName)
-                                    {
-                                        if (jb.FromID != 0)
-                                        {
-                                            wayPointSysID = jb.FromID;
-                                        }
-                                        break;
-                                    }
+                                    continue;
+                                }
 
-                                    if (jb.To == rp.SystemName)
+                                long wayPointSysID = waypointSystem.ID;
+
+                                if (rp.GateToTake == Navigation.GateType.Ansiblex)
+                                {
+                                    foreach (JumpBridge jb in EveManager.Instance.JumpBridges)
                                     {
-                                        if (jb.ToID != 0)
+                                        if (jb.From == rp.SystemName)
                                         {
-                                            wayPointSysID = jb.ToID;
+                                            if (jb.FromID != 0)
+                                            {
+                                                wayPointSysID = jb.FromID;
+                                            }
+                                            break;
                                         }
-                                        break;
+
+                                        if (jb.To == rp.SystemName)
+                                        {
+                                            if (jb.ToID != 0)
+                                            {
+                                                wayPointSysID = jb.ToID;
+                                            }
+                                            break;
+                                        }
                                     }
                                 }
+                                WayPointsToAdd.Add(wayPointSysID);
                             }
-                            WayPointsToAdd.Add(wayPointSysID);
                         }
                     }
-                }
 
-                bool firstRoute = true;
+                    bool firstRoute = true;
+                    Exception firstWaypointError = null;
 
-                AuthDTO auth = GetAuthDTO();
-                if (auth != null)
-                {
-                    foreach (long SysID in WayPointsToAdd)
+                    AuthDTO auth = GetAuthDTO();
+                    if (auth != null)
                     {
-                        try
+                        foreach (long SysID in WayPointsToAdd)
                         {
-                            await EveManager.Instance.EveApiClient.UserInterface.SetAutopilotWaypointAsync(auth, firstRoute, false, SysID);
+                            try
+                            {
+                                await EveManager.Instance.EveApiClient.UserInterface.SetAutopilotWaypointAsync(auth, firstRoute, false, SysID);
+                            }
+                            catch(Exception exception)
+                            {
+                                firstWaypointError ??= exception;
+                            }
+                            firstRoute = false;
+                            await Task.Delay(TimeSpan.FromMilliseconds(200)).ConfigureAwait(false);
                         }
-                        catch { }
-                        firstRoute = false;
-                        Thread.Sleep(200);
+                    }
+
+                    if(firstWaypointError != null)
+                    {
+                        EVEDataUtils.AppLog.Error($"Set autopilot route for {Name}", firstWaypointError);
                     }
                 }
-
-                esiRouteUpdating = false;
+                finally
+                {
+                    esiRouteUpdating = false;
+                }
             }
         }
 
@@ -1162,14 +1184,19 @@ namespace SMT.EVEData
                     {
                         try
                         {
-                            HttpClient hc = new HttpClient();
-                            var response = await hc.GetAsync(esri.Model.Px128x128);
+                            Directory.CreateDirectory(portraitRoot);
+                            using HttpClient hc = new HttpClient();
+                            using HttpResponseMessage response = await hc.GetAsync(esri.Model.Px128x128);
+                            response.EnsureSuccessStatusCode();
                             using (var fs = new FileStream(characterPortrait, FileMode.CreateNew))
                             {
                                 await response.Content.CopyToAsync(fs);
                             }
                         }
-                        catch { }
+                        catch(Exception exception)
+                        {
+                            EVEDataUtils.AppLog.Error($"Download portrait for {Name}", exception);
+                        }
                     }
                 }
 

--- a/EVEData/LocalCharacter.cs
+++ b/EVEData/LocalCharacter.cs
@@ -1041,7 +1041,7 @@ namespace SMT.EVEData
 
                         if (characterIDsToResolve.Count > 0)
                         {
-                            EveManager.Instance.ResolveCharacterIDs(characterIDsToResolve).Wait();
+                            await EveManager.Instance.ResolveCharacterIDs(characterIDsToResolve);
                         }
 
                         foreach (Fleet.FleetMember ff in FleetInfo.Members.ToList())

--- a/EVEData/Navigation.cs
+++ b/EVEData/Navigation.cs
@@ -100,16 +100,13 @@ namespace SMT.EVEData
         {
             List<string> inRange = new List<string>();
 
-            MapNode startSys = null;
-
-            foreach (MapNode sys in MapNodes.Values)
+            if(MapNodes == null || LY <= 0 || !MapNodes.TryGetValue(start, out MapNode startSys))
             {
-                if (sys.Name == start)
-                {
-                    startSys = sys;
-                    break;
-                }
+                return inRange;
             }
+
+            decimal maxDistance = (decimal)LY;
+            decimal maxDistanceSquared = maxDistance * maxDistance;
 
             foreach (MapNode sys in MapNodes.Values)
             {
@@ -122,21 +119,15 @@ namespace SMT.EVEData
                 decimal y = startSys.Y - sys.Y;
                 decimal z = startSys.Z - sys.Z;
 
-                decimal length = DecimalMath.DecimalEx.Sqrt((x * x) + (y * y) + (z * z));
+                decimal distanceSquared = (x * x) + (y * y) + (z * z);
+                bool shouldAdd = distanceSquared < maxDistanceSquared;
 
-                bool shouldAdd = false;
-
-                if (length < (decimal)LY)
-                {
-                    shouldAdd = true;
-                }
-
-                if (sys.HighSec & !includeHighSecSystems)
+                if (sys.HighSec && !includeHighSecSystems)
                 {
                     shouldAdd = false;
                 }
 
-                if (sys.Pochven & !includePochvenSystems)
+                if (sys.Pochven && !includePochvenSystems)
                 {
                     shouldAdd = false;
                 }
@@ -601,39 +592,42 @@ namespace SMT.EVEData
                 return null;
             }
 
-            double ExtraJumpFactor = 5.0;
-            double AvoidFactor = 0.0;
+            const double ExtraJumpFactor = 5.0;
+            HashSet<string> avoidSystems = systemsToAvoid == null ? new HashSet<string>() : new HashSet<string>(systemsToAvoid);
 
-            // clear the scores, values and parents from the list
-            foreach (MapNode mapNode in MapNodes.Values)
+            // Reset only nodes touched by the previous route calculation.
+            foreach (MapNode mapNode in LastTouchedNodes)
             {
                 mapNode.NearestToStart = null;
                 mapNode.MinCostToStart = 0;
                 mapNode.Visited = false;
             }
+            LastTouchedNodes.Clear();
 
             MapNode Start = MapNodes[From];
             MapNode End = MapNodes[To];
 
-            List<MapNode> OpenList = new List<MapNode>();
-            List<MapNode> ClosedList = new List<MapNode>();
+            SortedSet<MapNode> OpenList = new SortedSet<MapNode>(new MapNodeComparer());
+            HashSet<MapNode> OpenSet = new HashSet<MapNode>();
 
             MapNode CurrentNode = null;
 
             // add the start to the open list
             OpenList.Add(Start);
+            OpenSet.Add(Start);
+            LastTouchedNodes.Add(Start);
 
             while (OpenList.Count > 0)
             {
-                // get the MapNode with the lowest F score
-                double lowest = OpenList.Min(mn => mn.MinCostToStart);
-                CurrentNode = OpenList.First(mn => mn.MinCostToStart == lowest);
-
-                // add the list to the closed list
-                ClosedList.Add(CurrentNode);
-
-                // remove it from the open list
+                CurrentNode = OpenList.Min;
                 OpenList.Remove(CurrentNode);
+                OpenSet.Remove(CurrentNode);
+
+                // The lowest-cost destination has been found; no remaining nodes need processing.
+                if(CurrentNode == End)
+                {
+                    break;
+                }
 
                 // walk the connections
                 foreach (JumpLink connection in CurrentNode.JumpableSystems)
@@ -648,23 +642,22 @@ namespace SMT.EVEData
                     if (CMN.Visited)
                         continue;
 
-                    if (systemsToAvoid.Contains(connection.System))
-                    {
-                        AvoidFactor = 10000;
-                    }
-                    else
-                    {
-                        AvoidFactor = 0.0;
-                    }
+                    double avoidFactor = avoidSystems.Contains(connection.System) ? 10000.0 : 0.0;
+                    double newCostToStart = CurrentNode.MinCostToStart + (double)connection.RangeLY + ExtraJumpFactor + avoidFactor;
 
-                    if (CMN.MinCostToStart == 0 || CurrentNode.MinCostToStart + (double)connection.RangeLY + ExtraJumpFactor + AvoidFactor < CMN.MinCostToStart)
+                    if (CMN.MinCostToStart == 0 || newCostToStart < CMN.MinCostToStart)
                     {
-                        CMN.MinCostToStart = CurrentNode.MinCostToStart + (double)connection.RangeLY + ExtraJumpFactor + AvoidFactor;
-                        CMN.NearestToStart = CurrentNode;
-                        if (!OpenList.Contains(CMN))
+                        if(OpenSet.Contains(CMN))
                         {
-                            OpenList.Add(CMN);
+                            OpenList.Remove(CMN);
+                            OpenSet.Remove(CMN);
                         }
+
+                        CMN.MinCostToStart = newCostToStart;
+                        CMN.NearestToStart = CurrentNode;
+                        LastTouchedNodes.Add(CMN);
+                        OpenList.Add(CMN);
+                        OpenSet.Add(CMN);
                     }
                 }
 

--- a/EVEData/SOVCampaign.cs
+++ b/EVEData/SOVCampaign.cs
@@ -74,6 +74,53 @@ namespace SMT.EVEData
             }
         }
 
+        public void UpdateFrom(SOVCampaign source)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+
+            if(DefendingAllianceID != source.DefendingAllianceID)
+            {
+                DefendingAllianceID = source.DefendingAllianceID;
+                OnPropertyChanged(nameof(DefendingAllianceID));
+            }
+            if(DefendingAllianceName != source.DefendingAllianceName)
+            {
+                DefendingAllianceName = source.DefendingAllianceName;
+                OnPropertyChanged(nameof(DefendingAllianceName));
+            }
+            if(System != source.System)
+            {
+                System = source.System;
+                OnPropertyChanged(nameof(System));
+            }
+            if(Region != source.Region)
+            {
+                Region = source.Region;
+                OnPropertyChanged(nameof(Region));
+            }
+            if(Type != source.Type)
+            {
+                Type = source.Type;
+                OnPropertyChanged(nameof(Type));
+            }
+            if(State != source.State)
+            {
+                State = source.State;
+                OnPropertyChanged(nameof(State));
+            }
+            if(StartTime != source.StartTime)
+            {
+                StartTime = source.StartTime;
+                OnPropertyChanged(nameof(StartTime));
+            }
+
+            AttackersScore = source.AttackersScore;
+            DefendersScore = source.DefendersScore;
+            TimeToStart = source.TimeToStart;
+            IsActive = source.IsActive;
+            Valid = source.Valid;
+        }
+
         private bool m_Valid;
 
         public bool Valid
@@ -99,5 +146,6 @@ namespace SMT.EVEData
                 handler(this, new PropertyChangedEventArgs(name));
             }
         }
+
     }
 }

--- a/EVEData/Server.cs
+++ b/EVEData/Server.cs
@@ -4,10 +4,13 @@ using Timer = System.Timers.Timer;
 
 namespace SMT.EVEData
 {
-    public class Server : INotifyPropertyChanged
+    public class Server : INotifyPropertyChanged, IDisposable
     {
+        private readonly Timer timer;
         private int m_numPlayers;
         private string m_serverVersion;
+        private string m_statusMessage = "Ready";
+        private bool m_statusIsError;
 
         private DateTime m_serverTime;
 
@@ -16,8 +19,8 @@ namespace SMT.EVEData
             // EVE Time is basically UTC time
             ServerTime = DateTime.UtcNow;
 
-            Timer timer = new Timer(10000);
-            timer.Elapsed += new ElapsedEventHandler(UpdateServerTime); ;
+            timer = new Timer(10000);
+            timer.Elapsed += new ElapsedEventHandler(UpdateServerTime);
             timer.AutoReset = true;
             timer.Enabled = true;
         }
@@ -64,6 +67,35 @@ namespace SMT.EVEData
                 m_serverVersion = value;
                 OnPropertyChanged("ServerVersion");
             }
+        }
+
+        public string StatusMessage
+        {
+            get => m_statusMessage;
+            set
+            {
+                m_statusMessage = value;
+                OnPropertyChanged(nameof(StatusMessage));
+            }
+        }
+
+        public bool StatusIsError
+        {
+            get => m_statusIsError;
+            set
+            {
+                m_statusIsError = value;
+                OnPropertyChanged(nameof(StatusIsError));
+            }
+        }
+
+        public string LogFilePath => EVEDataUtils.AppLog.CurrentLogFile;
+
+        public void Dispose()
+        {
+            timer.Stop();
+            timer.Elapsed -= UpdateServerTime;
+            timer.Dispose();
         }
 
         public void UpdateServerTime(object sender, EventArgs e)

--- a/EVEData/Utils/AppLog.cs
+++ b/EVEData/Utils/AppLog.cs
@@ -1,0 +1,105 @@
+using System.Text;
+
+namespace EVEDataUtils
+{
+    /// <summary>
+    /// Lightweight, thread-safe application logging that never throws back into SMT.
+    /// </summary>
+    public static class AppLog
+    {
+        private const long MaxLogSizeBytes = 2 * 1024 * 1024;
+        private static readonly object SyncRoot = new object();
+        private static string logDirectory = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "SMT",
+            "Logs");
+
+        public static event Action<string, bool> StatusChanged;
+
+        public static string CurrentLogFile => Path.Combine(logDirectory, "SMT.log");
+
+        public static void Initialize(string directory)
+        {
+            if(!string.IsNullOrWhiteSpace(directory))
+            {
+                logDirectory = directory;
+            }
+
+            Info("Logging", "SMT logging initialized.");
+        }
+
+        public static void Info(string operation, string message)
+        {
+            Write("INFO", operation, message, false);
+        }
+
+        public static void Warning(string operation, string message)
+        {
+            Write("WARN", operation, message, true);
+        }
+
+        public static void Error(string operation, Exception exception)
+        {
+            string message = exception == null ? "Unknown error" : exception.ToString();
+            Write("ERROR", operation, message, true);
+        }
+
+        public static void Error(string operation, string message)
+        {
+            Write("ERROR", operation, message, true);
+        }
+
+        private static void Write(string level, string operation, string message, bool isError)
+        {
+            string statusMessage = $"{operation}: {FirstLine(message)}";
+
+            try
+            {
+                lock(SyncRoot)
+                {
+                    Directory.CreateDirectory(logDirectory);
+                    RotateIfNeeded();
+
+                    string entry = $"{DateTimeOffset.Now:O} [{level}] [{operation}] {message}{Environment.NewLine}";
+                    File.AppendAllText(CurrentLogFile, entry, new UTF8Encoding(false));
+                }
+            }
+            catch
+            {
+                // Logging must never cause an application failure.
+            }
+
+            try
+            {
+                StatusChanged?.Invoke(statusMessage, isError);
+            }
+            catch
+            {
+                // Status listeners are optional and must not affect application work.
+            }
+        }
+
+        private static void RotateIfNeeded()
+        {
+            FileInfo currentLog = new FileInfo(CurrentLogFile);
+            if(!currentLog.Exists || currentLog.Length < MaxLogSizeBytes)
+            {
+                return;
+            }
+
+            string previousLog = Path.Combine(logDirectory, "SMT.previous.log");
+            File.Move(CurrentLogFile, previousLog, true);
+        }
+
+        private static string FirstLine(string value)
+        {
+            if(string.IsNullOrWhiteSpace(value))
+            {
+                return "No details available";
+            }
+
+            int lineBreak = value.IndexOfAny(new[] { '\r', '\n' });
+            return lineBreak < 0 ? value : value.Substring(0, lineBreak);
+        }
+    }
+}

--- a/EVEData/Utils/AtomicFile.cs
+++ b/EVEData/Utils/AtomicFile.cs
@@ -1,0 +1,96 @@
+using System.Text;
+
+namespace EVEDataUtils
+{
+    /// <summary>
+    /// Writes files through a temporary file in the same directory and keeps one backup.
+    /// </summary>
+    public static class AtomicFile
+    {
+        public static string GetBackupPath(string fileName) => fileName + ".bak";
+
+        public static void Write(string fileName, Action<Stream> writeAction)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
+            ArgumentNullException.ThrowIfNull(writeAction);
+
+            string fullPath = Path.GetFullPath(fileName);
+            string directory = Path.GetDirectoryName(fullPath);
+            Directory.CreateDirectory(directory);
+
+            string temporaryPath = Path.Combine(directory, $".{Path.GetFileName(fullPath)}.{Guid.NewGuid():N}.tmp");
+            string backupPath = GetBackupPath(fullPath);
+
+            try
+            {
+                using(FileStream stream = new FileStream(
+                    temporaryPath,
+                    FileMode.CreateNew,
+                    FileAccess.Write,
+                    FileShare.None,
+                    4096,
+                    FileOptions.WriteThrough))
+                {
+                    writeAction(stream);
+                    stream.Flush(true);
+                }
+
+                if(File.Exists(fullPath))
+                {
+                    try
+                    {
+                        File.Replace(temporaryPath, fullPath, backupPath, true);
+                    }
+                    catch(PlatformNotSupportedException)
+                    {
+                        ReplaceFallback(temporaryPath, fullPath, backupPath);
+                    }
+                    catch(IOException)
+                    {
+                        ReplaceFallback(temporaryPath, fullPath, backupPath);
+                    }
+                }
+                else
+                {
+                    File.Move(temporaryPath, fullPath);
+                }
+            }
+            finally
+            {
+                if(File.Exists(temporaryPath))
+                {
+                    File.Delete(temporaryPath);
+                }
+            }
+        }
+
+        public static void WriteText(string fileName, Action<TextWriter> writeAction)
+        {
+            ArgumentNullException.ThrowIfNull(writeAction);
+
+            Write(fileName, stream =>
+            {
+                using StreamWriter writer = new StreamWriter(stream, new UTF8Encoding(false), 4096, true);
+                writeAction(writer);
+                writer.Flush();
+            });
+        }
+
+        public static void WriteAllLines(string fileName, IEnumerable<string> lines)
+        {
+            WriteText(fileName, writer =>
+            {
+                foreach(string line in lines)
+                {
+                    writer.WriteLine(line);
+                }
+            });
+        }
+
+        private static void ReplaceFallback(string temporaryPath, string fullPath, string backupPath)
+        {
+            File.Copy(fullPath, backupPath, true);
+            File.Move(temporaryPath, fullPath, true);
+        }
+    }
+}

--- a/EVEData/Utils/Serialization.cs
+++ b/EVEData/Utils/Serialization.cs
@@ -11,8 +11,8 @@ namespace EVEDataUtils
             {
                 XmlSerializer xms = new XmlSerializer(typeof(T));
 
-                FileStream fs = new FileStream(filename, FileMode.Open, FileAccess.Read);
-                XmlReader xmlr = XmlReader.Create(fs);
+                using FileStream fs = new FileStream(filename, FileMode.Open, FileAccess.Read);
+                using XmlReader xmlr = XmlReader.Create(fs);
 
                 return (T)xms.Deserialize(xmlr);
             }

--- a/EVEData/Utils/Serialization.cs
+++ b/EVEData/Utils/Serialization.cs
@@ -9,27 +9,55 @@ namespace EVEDataUtils
         {
             try
             {
-                XmlSerializer xms = new XmlSerializer(typeof(T));
-
-                using FileStream fs = new FileStream(filename, FileMode.Open, FileAccess.Read);
-                using XmlReader xmlr = XmlReader.Create(fs);
-
-                return (T)xms.Deserialize(xmlr);
+                return DeserializeFile<T>(filename);
             }
-            catch
+            catch(Exception primaryException)
             {
-                return default(T);
+                string backupFile = AtomicFile.GetBackupPath(filename);
+                if(File.Exists(backupFile))
+                {
+                    try
+                    {
+                        T recovered = DeserializeFile<T>(backupFile);
+                        AppLog.Warning("Load data", $"Recovered '{Path.GetFileName(filename)}' from its backup after: {primaryException.Message}");
+                        return recovered;
+                    }
+                    catch(Exception backupException)
+                    {
+                        AppLog.Error("Load data", new AggregateException(primaryException, backupException));
+                    }
+                }
+                else
+                {
+                    AppLog.Error("Load data", primaryException);
+                }
+
+                return default;
             }
         }
 
         public static void SerializeToDisk<T>(T obj, string fileName)
         {
+            try
+            {
+                XmlSerializer xms = new XmlSerializer(typeof(T));
+                AtomicFile.Write(fileName, stream => xms.Serialize(stream, obj));
+            }
+            catch(Exception exception)
+            {
+                AppLog.Error("Save data", exception);
+                throw;
+            }
+        }
+
+        private static T DeserializeFile<T>(string filename)
+        {
             XmlSerializer xms = new XmlSerializer(typeof(T));
 
-            using (TextWriter tw = new StreamWriter(fileName))
-            {
-                xms.Serialize(tw, obj);
-            }
+            using FileStream fs = new FileStream(filename, FileMode.Open, FileAccess.Read, FileShare.Read);
+            using XmlReader xmlr = XmlReader.Create(fs, new XmlReaderSettings { XmlResolver = null });
+
+            return (T)xms.Deserialize(xmlr);
         }
     }
 }

--- a/EVEData/ZKillRedisQ.cs
+++ b/EVEData/ZKillRedisQ.cs
@@ -2,26 +2,41 @@
 // ZKillboard R2Z2 feed
 //-----------------------------------------------------------------------
 using System.ComponentModel;
-using System.Net.Http;
+using System.Collections.ObjectModel;
 using System.Net;
-using Timer = System.Timers.Timer;
+using EVEDataUtils;
 
 namespace SMT.EVEData
 {
     /// <summary>
     /// The ZKillboard R2Z2 feed representation
     /// </summary>
-    public class ZKillRedisQ
+    public class ZKillRedisQ : IDisposable
     {
-        private BackgroundWorker backgroundWorker;
-
+        private readonly HttpClient httpClient;
+        private readonly object lifecycleLock = new object();
+        private readonly object allianceResolutionLock = new object();
+        private readonly HashSet<int> pendingAllianceResolutions = new HashSet<int>();
+        private CancellationTokenSource cancellationSource;
+        private Task pollingTask = Task.CompletedTask;
         private long currentSequence = 0;
-        private DateTime nextPollTime = DateTime.MinValue;
+        private volatile bool pauseUpdate;
+        private int killExpireTimeMinutes = 30;
+        private bool disposed;
+
+        public ZKillRedisQ()
+        {
+            httpClient = new HttpClient
+            {
+                Timeout = TimeSpan.FromSeconds(30),
+            };
+            httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("SMT/" + EveAppConfig.SMT_VERSION + EveAppConfig.SMT_USERAGENT_DETAILS);
+        }
 
         /// <summary>
         /// Gets or sets the Stream of the last few kills from ZKillBoard
         /// </summary>
-        public List<ZKBDataSimple> KillStream { get; set; }
+        public ObservableCollection<ZKBDataSimple> KillStream { get; } = new ObservableCollection<ZKBDataSimple>();
 
         /// <summary>
         /// Kills Added Event Handler
@@ -33,181 +48,287 @@ namespace SMT.EVEData
         /// </summary>
         public event KillsAddedHandler KillsAddedEvent;
 
-        public int KillExpireTimeMinutes { get; set; }
+        public int KillExpireTimeMinutes
+        {
+            get => Volatile.Read(ref killExpireTimeMinutes);
+            set => Volatile.Write(ref killExpireTimeMinutes, Math.Max(5, value));
+        }
 
         /// <summary>
         ///
         /// </summary>
-        public bool PauseUpdate { get; set; }
+        public bool PauseUpdate
+        {
+            get => pauseUpdate;
+            set => pauseUpdate = value;
+        }
+
+        public Task Completion
+        {
+            get
+            {
+                lock(lifecycleLock)
+                {
+                    return pollingTask;
+                }
+            }
+        }
 
         /// <summary>
         /// Initialise the ZKB feed system
         /// </summary>
         public void Initialise()
         {
-            KillStream = new List<ZKBDataSimple>();
+            lock(lifecycleLock)
+            {
+                ObjectDisposedException.ThrowIf(disposed, this);
+                if(!pollingTask.IsCompleted)
+                {
+                    return;
+                }
 
-            backgroundWorker = new BackgroundWorker();
-            backgroundWorker.WorkerSupportsCancellation = true;
-            backgroundWorker.WorkerReportsProgress = false;
-            backgroundWorker.DoWork += zkb_DoWork;
-            backgroundWorker.RunWorkerCompleted += zkb_DoWorkComplete;
-
-            Timer dp = new Timer(150);
-            dp.Elapsed += Dp_Tick;
-            dp.AutoReset = true;
-            dp.Enabled = true;
+                cancellationSource?.Dispose();
+                cancellationSource = new CancellationTokenSource();
+                currentSequence = 0;
+                RunOnUIThread(() => KillStream.Clear());
+                pollingTask = Task.Run(() => PollLoopAsync(cancellationSource.Token));
+            }
         }
 
         public void ShutDown()
         {
-            backgroundWorker.CancelAsync();
-        }
-
-        private void Dp_Tick(object sender, EventArgs e)
-        {
-            if(!backgroundWorker.IsBusy && !PauseUpdate && DateTime.Now >= nextPollTime)
+            lock(lifecycleLock)
             {
-                backgroundWorker.RunWorkerAsync();
+                cancellationSource?.Cancel();
             }
         }
 
-        private void zkb_DoWork(object sender, DoWorkEventArgs e)
+        public void Dispose()
+        {
+            lock(lifecycleLock)
+            {
+                if(disposed)
+                {
+                    return;
+                }
+
+                disposed = true;
+                cancellationSource?.Cancel();
+                cancellationSource?.Dispose();
+                httpClient.Dispose();
+            }
+        }
+
+        private async Task PollLoopAsync(CancellationToken cancellationToken)
+        {
+            while(!cancellationToken.IsCancellationRequested)
+            {
+                if(PauseUpdate)
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(250), cancellationToken).ConfigureAwait(false);
+                    continue;
+                }
+
+                try
+                {
+                    if(currentSequence == 0 && !await LoadCurrentSequenceAsync(cancellationToken).ConfigureAwait(false))
+                    {
+                        await Task.Delay(TimeSpan.FromSeconds(6), cancellationToken).ConfigureAwait(false);
+                        continue;
+                    }
+
+                    TimeSpan delay = await PollCurrentSequenceAsync(cancellationToken).ConfigureAwait(false);
+                    await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+                }
+                catch(OperationCanceledException) when(cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch(Exception exception)
+                {
+                    AppLog.Error("ZKill feed", exception);
+                    await Task.Delay(TimeSpan.FromSeconds(10), cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+
+        private async Task<bool> LoadCurrentSequenceAsync(CancellationToken cancellationToken)
+        {
+            using HttpResponseMessage response = await httpClient.GetAsync(
+                "https://r2z2.zkillboard.com/ephemeral/sequence.json",
+                cancellationToken).ConfigureAwait(false);
+
+            if(!response.IsSuccessStatusCode)
+            {
+                return false;
+            }
+
+            string content = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            ZKBData.SequenceData sequenceData = ZKBData.SequenceData.FromJson(content);
+            if(sequenceData == null || sequenceData.Sequence <= 0)
+            {
+                return false;
+            }
+
+            currentSequence = sequenceData.Sequence;
+            AppLog.Info("ZKill feed", "Connected to the live feed.");
+            return true;
+        }
+
+        private async Task<TimeSpan> PollCurrentSequenceAsync(CancellationToken cancellationToken)
+        {
+            string requestUrl = $"https://r2z2.zkillboard.com/ephemeral/{currentSequence}.json";
+            using HttpResponseMessage response = await httpClient.GetAsync(requestUrl, cancellationToken).ConfigureAwait(false);
+
+            if(response.StatusCode == HttpStatusCode.NotFound)
+            {
+                ExpireOldKills();
+                return TimeSpan.FromSeconds(6);
+            }
+
+            if(response.StatusCode == HttpStatusCode.TooManyRequests)
+            {
+                return response.Headers.RetryAfter?.Delta ?? TimeSpan.FromSeconds(60);
+            }
+
+            response.EnsureSuccessStatusCode();
+            string content = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            ZKBData.R2Z2Data data = ZKBData.R2Z2Data.FromJson(content);
+
+            if(data?.Esi?.Victim != null)
+            {
+                ZKBDataSimple kill = CreateKill(data);
+                RunOnUIThread(() =>
+                {
+                    KillStream.Insert(0, kill);
+                    ExpireOldKillsCore();
+                    NotifyKillsChanged();
+                });
+
+                QueueAllianceResolution(kill.VictimAllianceID, kill.VictimAllianceName);
+            }
+            else
+            {
+                ExpireOldKills();
+            }
+
+            currentSequence++;
+            return TimeSpan.FromMilliseconds(150);
+        }
+
+        private static ZKBDataSimple CreateKill(ZKBData.R2Z2Data data)
+        {
+            string shipID = data.Esi.Victim.ShipTypeId.ToString();
+            string shipType = EveManager.Instance.ShipTypes.TryGetValue(shipID, out string knownShipType)
+                ? knownShipType
+                : "Unknown (" + shipID + ")";
+
+            return new ZKBDataSimple
+            {
+                KillID = data.KillmailId,
+                VictimAllianceID = data.Esi.Victim.AllianceId,
+                VictimCharacterID = data.Esi.Victim.CharacterId,
+                VictimCorpID = data.Esi.Victim.CorporationId,
+                SystemName = EveManager.Instance.GetEveSystemNameFromID((int)data.Esi.SolarSystemId),
+                KillTime = data.Esi.KillmailTime.ToLocalTime(),
+                ShipType = shipType,
+                VictimAllianceName = EveManager.Instance.GetAllianceName(data.Esi.Victim.AllianceId),
+            };
+        }
+
+        private void QueueAllianceResolution(int allianceID, string allianceName)
+        {
+            if(allianceID == 0 || !string.IsNullOrEmpty(allianceName))
+            {
+                return;
+            }
+
+            lock(allianceResolutionLock)
+            {
+                if(!pendingAllianceResolutions.Add(allianceID))
+                {
+                    return;
+                }
+            }
+
+            _ = ResolveAllianceNameAsync(allianceID);
+        }
+
+        private async Task ResolveAllianceNameAsync(int allianceID)
         {
             try
             {
-                HttpClient hc = new HttpClient();
-
-                string userAgent = "SMT/" + EveAppConfig.SMT_VERSION + EveAppConfig.SMT_USERAGENT_DETAILS;
-                hc.DefaultRequestHeaders.Add("User-Agent", userAgent);
-
-                if (currentSequence == 0)
+                await EveManager.Instance.ResolveAllianceIDs(new List<int> { allianceID }).ConfigureAwait(false);
+                string allianceName = EveManager.Instance.GetAllianceName(allianceID);
+                RunOnUIThread(() =>
                 {
-                    string seqUrl = "https://r2z2.zkillboard.com/ephemeral/sequence.json";
-                    var seqResponse = hc.GetAsync(seqUrl).Result;
-                    if (seqResponse.IsSuccessStatusCode)
+                    foreach(ZKBDataSimple kill in KillStream.Where(kill => kill.VictimAllianceID == allianceID))
                     {
-                        string seqContent = seqResponse.Content.ReadAsStringAsync().Result;
-                        ZKBData.SequenceData seqData = ZKBData.SequenceData.FromJson(seqContent);
-                        if (seqData != null)
-                        {
-                            currentSequence = seqData.Sequence;
-                        }
+                        kill.VictimAllianceName = allianceName;
                     }
-                    if (currentSequence == 0)
-                    {
-                        nextPollTime = DateTime.Now.AddSeconds(6);
-                        e.Result = 0;
-                        return;
-                    }
-                }
-
-                string r2z2Url = $"https://r2z2.zkillboard.com/ephemeral/{currentSequence}.json";
-                var response = hc.GetAsync(r2z2Url).Result;
-
-                if (response.StatusCode == HttpStatusCode.NotFound)
-                {
-                    nextPollTime = DateTime.Now.AddSeconds(6);
-                    e.Result = 0;
-                    return;
-                }
-                else if (response.StatusCode == HttpStatusCode.TooManyRequests)
-                {
-                    nextPollTime = DateTime.Now.AddSeconds(60);
-                    e.Result = 0;
-                    return;
-                }
-                else if (response.IsSuccessStatusCode)
-                {
-                    string strContent = response.Content.ReadAsStringAsync().Result;
-                    ZKBData.R2Z2Data r2z2Data = ZKBData.R2Z2Data.FromJson(strContent);
-
-                    if (r2z2Data != null && r2z2Data.Esi != null && r2z2Data.Esi.Victim != null)
-                    {
-                        ZKBDataSimple zs = new ZKBDataSimple();
-                        zs.KillID = r2z2Data.KillmailId;
-                        zs.VictimAllianceID = r2z2Data.Esi.Victim.AllianceId;
-                        zs.VictimCharacterID = r2z2Data.Esi.Victim.CharacterId;
-                        zs.VictimCorpID = r2z2Data.Esi.Victim.CorporationId;
-                        zs.SystemName = EveManager.Instance.GetEveSystemNameFromID((int)r2z2Data.Esi.SolarSystemId);
-                        zs.KillTime = r2z2Data.Esi.KillmailTime.ToLocalTime();
-
-                        string shipID = r2z2Data.Esi.Victim.ShipTypeId.ToString();
-                        if(EveManager.Instance.ShipTypes.ContainsKey(shipID))
-                        {
-                            zs.ShipType = EveManager.Instance.ShipTypes[shipID];
-                        }
-                        else
-                        {
-                            zs.ShipType = "Unknown (" + shipID + ")";
-                        }
-
-                        zs.VictimAllianceName = EveManager.Instance.GetAllianceName(zs.VictimAllianceID);
-
-                        KillStream.Insert(0, zs);
-
-                        if(KillsAddedEvent != null)
-                        {
-                            KillsAddedEvent();
-                        }
-                    }
-
-                    currentSequence++;
-                    e.Result = 0;
-                }
-                else
-                {
-                    // Any other error, just back off for a bit
-                    nextPollTime = DateTime.Now.AddSeconds(10);
-                    e.Result = -1;
-                }
+                });
             }
-            catch
+            catch(Exception exception)
             {
-                nextPollTime = DateTime.Now.AddSeconds(10);
-                e.Result = -1;
+                AppLog.Error("Resolve zKill alliance", exception);
+            }
+            finally
+            {
+                lock(allianceResolutionLock)
+                {
+                    pendingAllianceResolutions.Remove(allianceID);
+                }
             }
         }
 
-        private void zkb_DoWorkComplete(object sender, RunWorkerCompletedEventArgs e)
+        private void ExpireOldKills()
         {
-            bool updatedKillList = false;
-
-            List<int> AllianceIDs = new List<int>();
-
-            for(int i = KillStream.Count - 1; i >= 0; i--)
+            RunOnUIThread(() =>
             {
-                if(KillStream[i].VictimAllianceName == string.Empty)
+                if(ExpireOldKillsCore())
                 {
-                    if(!EveManager.Instance.AllianceIDToTicker.ContainsKey(KillStream[i].VictimAllianceID) && !AllianceIDs.Contains(KillStream[i].VictimAllianceID) && KillStream[i].VictimAllianceID != 0)
-                    {
-                        AllianceIDs.Add(KillStream[i].VictimAllianceID);
-                    }
-                    else
-                    {
-                        KillStream[i].VictimAllianceName = EveManager.Instance.GetAllianceName(KillStream[i].VictimAllianceID);
-                    }
+                    NotifyKillsChanged();
                 }
+            });
+        }
 
-                if(KillStream[i].KillTime + TimeSpan.FromMinutes(KillExpireTimeMinutes) < DateTimeOffset.Now)
+        private void NotifyKillsChanged()
+        {
+            try
+            {
+                KillsAddedEvent?.Invoke();
+            }
+            catch(Exception exception)
+            {
+                AppLog.Error("Update zKill UI", exception);
+            }
+        }
+
+        private bool ExpireOldKillsCore()
+        {
+            bool changed = false;
+            DateTimeOffset cutoff = DateTimeOffset.Now - TimeSpan.FromMinutes(KillExpireTimeMinutes);
+            for(int index = KillStream.Count - 1; index >= 0; index--)
+            {
+                if(KillStream[index].KillTime < cutoff)
                 {
-                    KillStream.RemoveAt(i);
-
-                    updatedKillList = true;
+                    KillStream.RemoveAt(index);
+                    changed = true;
                 }
             }
-            if(AllianceIDs.Count > 0)
-            {
-                _ = EveManager.Instance.ResolveAllianceIDs(AllianceIDs);
-            }
 
-            if(updatedKillList)
+            return changed;
+        }
+
+        private static void RunOnUIThread(Action action)
+        {
+            if(EveManager.UIThreadInvoker != null)
             {
-                // kills are coming in so fast that this is redundant
-                if(KillsAddedEvent != null)
-                {
-                    KillsAddedEvent();
-                }
+                EveManager.UIThreadInvoker(action);
+            }
+            else
+            {
+                action();
             }
         }
 

--- a/SMT/CharactersWindow.xaml.cs
+++ b/SMT/CharactersWindow.xaml.cs
@@ -45,6 +45,7 @@ namespace SMT
             }
 
             MainWindow mw = Owner as MainWindow;
+            mw.EVEManager.SaveCharacters();
             mw.EVEManager.LocalCharacterUpdateEvent -= EVEManager_LocalCharacterUpdateEvent;
         }
 

--- a/SMT/Languages/en-US.xaml
+++ b/SMT/Languages/en-US.xaml
@@ -206,6 +206,10 @@
     <s:String x:Key="Main_JP_GrpAlt">Alternate Mids</s:String>
     <s:String x:Key="Main_JP_LblAltFor">Alternates for :</s:String>
     <s:String x:Key="Main_JP_CtxUseAlt">Use Alt</s:String>
+    <s:String x:Key="Main_JP_SummaryNeedWP">Add at least two waypoints.</s:String>
+    <s:String x:Key="Main_JP_SummaryNoRoute">No valid route for {0}.</s:String>
+    <s:String x:Key="Main_JP_SummaryReady">{0} jumps, {1} mids, {2:0.##} LY total</s:String>
+    <s:String x:Key="Main_JP_CopySuccess">Route copied to the clipboard.</s:String>
 
     <s:String x:Key="Main_WH_TabThera">Thera</s:String>
     <s:String x:Key="Main_WH_TabTurnur">Turnur</s:String>

--- a/SMT/Languages/zh-CN.xaml
+++ b/SMT/Languages/zh-CN.xaml
@@ -205,6 +205,10 @@
     <s:String x:Key="Main_JP_GrpAlt">备选中转星系</s:String>
     <s:String x:Key="Main_JP_LblAltFor">正在查看谁的备选：</s:String>
     <s:String x:Key="Main_JP_CtxUseAlt">替换为此备选</s:String>
+    <s:String x:Key="Main_JP_SummaryNeedWP">请至少添加两个节点。</s:String>
+    <s:String x:Key="Main_JP_SummaryNoRoute">无法为 {0} 找到有效路线。</s:String>
+    <s:String x:Key="Main_JP_SummaryReady">{0} 次跳跃，{1} 个中转，总计 {2:0.##} 光年</s:String>
+    <s:String x:Key="Main_JP_CopySuccess">路线已复制到剪贴板。</s:String>
 
     <s:String x:Key="Main_WH_TabThera">希拉洞(Thera)</s:String>
     <s:String x:Key="Main_WH_TabTurnur">图尔努尔 (Turnur)</s:String>

--- a/SMT/LogonWindow.xaml.cs
+++ b/SMT/LogonWindow.xaml.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
+using EVEDataUtils;
 
 namespace SMT
 {
@@ -11,39 +13,35 @@ namespace SMT
     public partial class LogonWindow : Window
     {
         private HttpListener listener;
+        private readonly CancellationTokenSource cancellationSource = new CancellationTokenSource();
+        private readonly Task serverTask;
 
         public LogonWindow()
         {
             InitializeComponent();
-            new Task(StartServer).Start();
+            serverTask = StartServerAsync(cancellationSource.Token);
         }
 
-        private bool serverDone = false;
-
-        private void StartServer()
+        private async Task StartServerAsync(CancellationToken cancellationToken)
         {
-            // create the http Server
-            listener = new HttpListener();
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
-            string challengeCode = EVEDataUtils.Misc.RandomString(32);
-            string esiLogonURL = EVEData.EveManager.Instance.GetESILogonURL(challengeCode);
-
-            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(esiLogonURL) { UseShellExecute = true });
-
             try
             {
+                // Create the local callback server before opening the browser so startup failures are observable.
+                listener = new HttpListener();
+                ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+                string challengeCode = EVEDataUtils.Misc.RandomString(32);
+                string esiLogonURL = EVEData.EveManager.Instance.GetESILogonURL(challengeCode);
+
                 listener.Prefixes.Add(EVEData.EveAppConfig.CallbackURL);
                 listener.Start();
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(esiLogonURL) { UseShellExecute = true });
 
-                while (!serverDone)
+                while(!cancellationToken.IsCancellationRequested)
                 {
-                    Console.WriteLine("Listening...");
-
-                    // Note: The GetContext method blocks while waiting for a request.
-                    HttpListenerContext context = listener.GetContext();
+                    HttpListenerContext context = await listener.GetContextAsync().WaitAsync(cancellationToken);
                     HttpListenerRequest request = context.Request;
 
-                    EVEData.EveManager.Instance.HandleEveAuthSMTUri(request.Url, challengeCode);
+                    await EVEData.EveManager.Instance.HandleEveAuthSMTUriAsync(request.Url, challengeCode);
 
                     // Obtain a response object.
                     HttpListenerResponse response = context.Response;
@@ -54,28 +52,42 @@ namespace SMT
                     byte[] buffer = System.Text.Encoding.UTF8.GetBytes(responseString);
                     // Get a response stream and write the response to it.
                     response.ContentLength64 = buffer.Length;
-                    System.IO.Stream output = response.OutputStream;
-                    output.Write(buffer, 0, buffer.Length);
+                    await using System.IO.Stream output = response.OutputStream;
+                    await output.WriteAsync(buffer, cancellationToken);
                 }
             }
-            catch
+            catch(OperationCanceledException) when(cancellationToken.IsCancellationRequested)
             {
+            }
+            catch(HttpListenerException) when(cancellationToken.IsCancellationRequested)
+            {
+            }
+            catch(Exception exception)
+            {
+                AppLog.Error("ESI login listener", exception);
             }
         }
 
-        private void Window_Closed(object sender, EventArgs e)
+        private async void Window_Closed(object sender, EventArgs e)
         {
             try
             {
-                serverDone = true;
+                cancellationSource.Cancel();
 
                 if (listener != null && listener.IsListening)
                 {
                     listener.Stop();
                 }
+                listener?.Close();
+                await serverTask;
             }
-            catch
+            catch(Exception exception)
             {
+                AppLog.Error("Close ESI login listener", exception);
+            }
+            finally
+            {
+                cancellationSource.Dispose();
             }
         }
     }

--- a/SMT/MainWindow.Debug.cs
+++ b/SMT/MainWindow.Debug.cs
@@ -30,9 +30,9 @@ namespace SMT
 {
     public partial class MainWindow
     {
-        private void ForceESIUpdate_MenuItem_Click(object sender, RoutedEventArgs e)
+        private async void ForceESIUpdate_MenuItem_Click(object sender, RoutedEventArgs e)
         {
-            EVEManager.UpdateESIUniverseData();
+            await EVEManager.UpdateESIUniverseDataAsync();
         }
 
         private void ClearOldEVELogs_Click(object sender, RoutedEventArgs e)

--- a/SMT/MainWindow.Lifecycle.cs
+++ b/SMT/MainWindow.Lifecycle.cs
@@ -166,7 +166,7 @@ namespace SMT
                     {
                         if(s.CustomUniverseLayout)
                         {
-                            tw.WriteLine($"{s.Region},{s.Name},{s.UniverseX},{s.UniverseY}");
+                            tw.WriteLine($"{s.Region},{s.Name},{s.UniverseX.ToString(CultureInfo.InvariantCulture)},{s.UniverseY.ToString(CultureInfo.InvariantCulture)}");
                         }
                     }
                 }

--- a/SMT/MainWindow.Lifecycle.cs
+++ b/SMT/MainWindow.Lifecycle.cs
@@ -15,6 +15,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
@@ -25,6 +26,7 @@ using System.Windows.Threading;
 using System.Xml;
 using System.Xml.Serialization;
 using static SMT.EVEData.ZKillRedisQ;
+using EVEDataUtils;
 
 namespace SMT
 {
@@ -37,29 +39,72 @@ namespace SMT
         }
         private void SaveDefaultLayout()
         {
-            // first delete the existing
             string defaultLayoutFile = AppDomain.CurrentDomain.BaseDirectory + @"\DefaultWindowLayout.dat";
-
-            if(File.Exists(defaultLayoutFile))
-            {
-                File.Delete(defaultLayoutFile);
-            }
 
             try
             {
                 if(OperatingSystem.IsWindows())
                 {
                     AvalonDock.Layout.Serialization.XmlLayoutSerializer ls = new AvalonDock.Layout.Serialization.XmlLayoutSerializer(dockManager);
-                    using(var sw = new StreamWriter(defaultLayoutFile))
-                    {
-                        ls.Serialize(sw);
-                    }
+                    AtomicFile.WriteText(defaultLayoutFile, writer => ls.Serialize(writer));
                 }
             }
-            catch
+            catch(Exception exception)
             {
+                AppLog.Error("Save default layout", exception);
             }
         }
+
+        private void LoadWindowLayoutWithBackup(string layoutFile)
+        {
+            if(!OperatingSystem.IsWindows())
+            {
+                return;
+            }
+
+            string backupFile = AtomicFile.GetBackupPath(layoutFile);
+            string candidate = File.Exists(layoutFile) ? layoutFile : File.Exists(backupFile) ? backupFile : null;
+            if(candidate == null)
+            {
+                return;
+            }
+
+            try
+            {
+                DeserializeWindowLayout(candidate);
+                if(candidate == backupFile)
+                {
+                    AppLog.Warning("Load window layout", "The backup layout was loaded because the primary file was missing.");
+                }
+            }
+            catch(Exception primaryException)
+            {
+                if(candidate == layoutFile && File.Exists(backupFile))
+                {
+                    try
+                    {
+                        DeserializeWindowLayout(backupFile);
+                        AppLog.Warning("Load window layout", $"Recovered the window layout from backup after: {primaryException.Message}");
+                        return;
+                    }
+                    catch(Exception backupException)
+                    {
+                        AppLog.Error("Load window layout", new AggregateException(primaryException, backupException));
+                        return;
+                    }
+                }
+
+                AppLog.Error("Load window layout", primaryException);
+            }
+        }
+
+        private void DeserializeWindowLayout(string layoutFile)
+        {
+            AvalonDock.Layout.Serialization.XmlLayoutSerializer serializer = new AvalonDock.Layout.Serialization.XmlLayoutSerializer(dockManager);
+            using StreamReader reader = new StreamReader(layoutFile);
+            serializer.Deserialize(reader);
+        }
+
         private void Exit_MenuItem_Click(object sender, RoutedEventArgs e)
         {
             System.Windows.Application.Current.Shutdown();
@@ -111,6 +156,22 @@ namespace SMT
             Properties.Settings.Default.Save();
 
             EVEManager.ZKillFeed.KillsAddedEvent -= OnZKillsAdded;
+            AppLog.StatusChanged -= AppLog_StatusChanged;
+            EVEManager.BeginShutdown();
+        }
+
+        private void AppLog_StatusChanged(string message, bool isError)
+        {
+            if(Dispatcher.HasShutdownStarted)
+            {
+                return;
+            }
+
+            Dispatcher.BeginInvoke(() =>
+            {
+                EVEManager.ServerInfo.StatusMessage = message;
+                EVEManager.ServerInfo.StatusIsError = isError;
+            });
         }
         private void MainWindow_Closed(object sender, EventArgs e)
         {
@@ -120,13 +181,11 @@ namespace SMT
             try
             {
                 AvalonDock.Layout.Serialization.XmlLayoutSerializer ls = new AvalonDock.Layout.Serialization.XmlLayoutSerializer(dockManager);
-                using(var sw = new StreamWriter(dockManagerLayoutName))
-                {
-                    ls.Serialize(sw);
-                }
+                AtomicFile.WriteText(dockManagerLayoutName, writer => ls.Serialize(writer));
             }
-            catch
+            catch(Exception exception)
             {
+                AppLog.Error("Save window layout", exception);
             }
 
             try
@@ -151,16 +210,12 @@ namespace SMT
                 MapConf.ToolBox_ESIOverlayScale = RegionUC.ESIOverlayScale;
 
                 // now serialise the class to disk
-                XmlSerializer xms = new XmlSerializer(typeof(MapConfig));
-                using(TextWriter tw = new StreamWriter(mapConfigFileName))
-                {
-                    xms.Serialize(tw, MapConf);
-                }
+                Serialization.SerializeToDisk(MapConf, mapConfigFileName);
 
                 // Save any custom map Layout
                 string customLayoutFile = Path.Combine(EveAppConfig.VersionStorage, "CustomUniverseLayout.txt");
 
-                using(TextWriter tw = new StreamWriter(customLayoutFile))
+                AtomicFile.WriteText(customLayoutFile, tw =>
                 {
                     foreach(EVEData.System s in EVEManager.Systems)
                     {
@@ -169,31 +224,41 @@ namespace SMT
                             tw.WriteLine($"{s.Region},{s.Name},{s.UniverseX.ToString(CultureInfo.InvariantCulture)},{s.UniverseY.ToString(CultureInfo.InvariantCulture)}");
                         }
                     }
-                }
+                });
             }
-            catch
+            catch(Exception exception)
             {
+                AppLog.Error("Save map configuration", exception);
             }
 
             try
             {
                 // save the Anom Data
                 // now serialise the class to disk
-                XmlSerializer anomxms = new XmlSerializer(typeof(EVEData.AnomManager));
                 string anomDataFilename = EVEManager.SaveDataVersionFolder + @"\Anoms.dat";
-
-                using(TextWriter tw = new StreamWriter(anomDataFilename))
-                {
-                    anomxms.Serialize(tw, ANOMManager);
-                }
+                Serialization.SerializeToDisk(ANOMManager, anomDataFilename);
             }
-            catch
+            catch(Exception exception)
             {
+                AppLog.Error("Save anomaly data", exception);
             }
 
             // save the character data
-            EVEManager.SaveData();
+            try
+            {
+                EVEManager.SaveData();
+            }
+            catch(Exception exception)
+            {
+                AppLog.Error("Save application data", exception);
+            }
             EVEManager.ShutDown();
+
+            waveOutEvent?.Stop();
+            waveOutEvent?.Dispose();
+            audioFileReader?.Dispose();
+            nIcon.Visible = false;
+            nIcon.Dispose();
         }
         private void MainWindow_StateChanged(object sender, EventArgs e)
         {
@@ -262,41 +327,46 @@ namespace SMT
                 ActiveCharacter.RecalcRoute();
             }
         }
-        private async void CheckGitHubVersion()
+        private async Task CheckGitHubVersionAsync()
         {
             string url = @"https://api.github.com/repos/slazanger/smt/releases/latest";
             string strContent = string.Empty;
 
             try
             {
-                HttpClient hc = new HttpClient();
+                using HttpClient hc = new HttpClient();
                 hc.DefaultRequestHeaders.UserAgent.Add(new System.Net.Http.Headers.ProductInfoHeaderValue("SMT", EveAppConfig.SMT_VERSION));
-                var response = await hc.GetAsync(url);
+                using HttpResponseMessage response = await hc.GetAsync(url);
                 response.EnsureSuccessStatusCode();
                 strContent = await response.Content.ReadAsStringAsync();
             }
-            catch
+            catch(Exception exception)
             {
+                AppLog.Error("Check for SMT updates", exception);
                 return;
             }
 
-            GitHubRelease.Release releaseInfo = GitHubRelease.Release.FromJson(strContent);
-
-            if(releaseInfo != null)
+            try
             {
-                if(releaseInfo.TagName != EveAppConfig.SMT_VERSION)
+                GitHubRelease.Release releaseInfo = GitHubRelease.Release.FromJson(strContent);
+
+                if(releaseInfo != null && releaseInfo.TagName != EveAppConfig.SMT_VERSION)
                 {
-                    Application.Current.Dispatcher.Invoke((Action)(() =>
+                    await Application.Current.Dispatcher.InvokeAsync(() =>
                     {
                         NewVersionWindow nw = new NewVersionWindow();
                         nw.ReleaseInfo = releaseInfo.Body;
                         nw.CurrentVersion = EveAppConfig.SMT_VERSION;
                         nw.NewVersion = releaseInfo.TagName;
-                        nw.ReleaseURL = releaseInfo.HtmlUrl.ToString();
+                        nw.ReleaseURL = releaseInfo.HtmlUrl?.ToString() ?? string.Empty;
                         nw.Owner = this;
                         nw.ShowDialog();
-                    }), DispatcherPriority.Normal);
+                    }, DispatcherPriority.Normal);
                 }
+            }
+            catch(Exception exception)
+            {
+                AppLog.Error("Process SMT update information", exception);
             }
         }
         private void miResetLayout_Click(object sender, RoutedEventArgs e)
@@ -312,8 +382,9 @@ namespace SMT
                         ls.Deserialize(sr);
                     }
                 }
-                catch
+                catch(Exception exception)
                 {
+                    AppLog.Error("Reset window layout", exception);
                 }
             }
 

--- a/SMT/MainWindow.RoutingAndAnoms.cs
+++ b/SMT/MainWindow.RoutingAndAnoms.cs
@@ -31,9 +31,12 @@ namespace SMT
 {
     public partial class MainWindow
     {
-        private void btn_UpdateThera_Click(object sender, RoutedEventArgs e)
+        private Point capitalWaypointDragStart;
+        private string draggedCapitalWaypoint;
+
+        private async void btn_UpdateThera_Click(object sender, RoutedEventArgs e)
         {
-            EVEManager.UpdateTheraConnections();
+            await EVEManager.UpdateTheraConnectionsAsync();
         }
 
         private void TheraConnectionsList_MouseDoubleClick(object sender, MouseButtonEventArgs e)
@@ -54,9 +57,9 @@ namespace SMT
             }
         }
 
-        private void btn_UpdateTurnur_Click(object sender, RoutedEventArgs e)
+        private async void btn_UpdateTurnur_Click(object sender, RoutedEventArgs e)
         {
-            EVEManager.UpdateTurnurConnections();
+            await EVEManager.UpdateTurnurConnectionsAsync();
         }
 
         private void TurnurConnectionsList_MouseDoubleClick(object sender, MouseButtonEventArgs e)
@@ -76,32 +79,44 @@ namespace SMT
                 }
             }
         }
-        private void refreshJumpRouteUI()
+        private void RefreshJumpRouteUI()
         {
-            Application.Current.Dispatcher.Invoke((Action)(() =>
+            if(lbAlternateMids.ItemsSource != null)
             {
-                if(capitalRouteWaypointsLB.ItemsSource != null)
-                {
-                    CollectionViewSource.GetDefaultView(capitalRouteWaypointsLB.ItemsSource).Refresh();
-                }
+                CollectionViewSource.GetDefaultView(lbAlternateMids.ItemsSource).Refresh();
+            }
+        }
 
-                if(capitalRouteAvoidLB.ItemsSource != null)
-                {
-                    CollectionViewSource.GetDefaultView(capitalRouteAvoidLB.ItemsSource).Refresh();
-                }
+        private void RecalculateCapitalRouteAndRefresh()
+        {
+            CapitalRoute.Recalculate();
 
-                if(dgCapitalRouteCurrentRoute.ItemsSource != null)
-                {
-                    CollectionViewSource.GetDefaultView(dgCapitalRouteCurrentRoute.ItemsSource).Refresh();
-                }
+            if(CapitalRoute.WayPoints.Count < 2)
+            {
+                lblCapitalRouteSummary.Content = GetResourceText("Main_JP_SummaryNeedWP", "Add at least two waypoints.");
+            }
+            else if(CapitalRoute.CurrentRoute.Count == 0)
+            {
+                string format = GetResourceText("Main_JP_SummaryNoRoute", "No valid route for {0}.");
+                lblCapitalRouteSummary.Content = string.Format(CultureInfo.CurrentCulture, format, CapitalRoute.FailedSegment);
+            }
+            else
+            {
+                string format = GetResourceText("Main_JP_SummaryReady", "{0} jumps, {1} mids, {2:0.##} LY total");
+                lblCapitalRouteSummary.Content = string.Format(
+                    CultureInfo.CurrentCulture,
+                    format,
+                    CapitalRoute.JumpCount,
+                    CapitalRoute.MidCount,
+                    CapitalRoute.TotalDistance);
+            }
 
-                // lbAlternateMids could be null, need to check..
+            RefreshJumpRouteUI();
+        }
 
-                if(lbAlternateMids.ItemsSource != null)
-                {
-                    CollectionViewSource.GetDefaultView(lbAlternateMids.ItemsSource).Refresh();
-                }
-            }), DispatcherPriority.Normal, null);
+        private static string GetResourceText(string key, string fallback)
+        {
+            return Application.Current.TryFindResource(key) as string ?? fallback;
         }
 
         private void AddWaypointsBtn_Click(object sender, RoutedEventArgs e)
@@ -133,19 +148,11 @@ namespace SMT
 
             if(s != null)
             {
-                CapitalRoute.WayPoints.Add(s.Name);
-                CapitalRoute.Recalculate();
-
-                if(CapitalRoute.CurrentRoute.Count == 0)
+                if(!CapitalRoute.WayPoints.Contains(s.Name))
                 {
-                    lblCapitalRouteSummary.Content = "No Valid Route Found";
+                    CapitalRoute.WayPoints.Add(s.Name);
+                    RecalculateCapitalRouteAndRefresh();
                 }
-                else
-                {
-                    lblCapitalRouteSummary.Content = $"{CapitalRoute.CurrentRoute.Count - 2} Mids";
-                }
-
-                refreshJumpRouteUI();
             }
         }
 
@@ -159,19 +166,11 @@ namespace SMT
 
             if(s != null)
             {
-                CapitalRoute.AvoidSystems.Add(s.Name);
-                CapitalRoute.Recalculate();
-
-                if(CapitalRoute.CurrentRoute.Count == 0)
+                if(!CapitalRoute.AvoidSystems.Contains(s.Name))
                 {
-                    lblCapitalRouteSummary.Content = "No Valid Route Found";
+                    CapitalRoute.AvoidSystems.Add(s.Name);
+                    RecalculateCapitalRouteAndRefresh();
                 }
-                else
-                {
-                    lblCapitalRouteSummary.Content = $"{CapitalRoute.CurrentRoute.Count - 2} Mids";
-                }
-
-                refreshJumpRouteUI();
             }
         }
 
@@ -190,14 +189,13 @@ namespace SMT
             CapitalRoute.CurrentRoute.Clear();
             lbAlternateMids.ItemsSource = null;
             lblAlternateMids.Content = "";
-
-            refreshJumpRouteUI();
+            RecalculateCapitalRouteAndRefresh();
         }
 
         private void ClearJumpAvoidSystemsBtn_Click(object sender, RoutedEventArgs e)
         {
             CapitalRoute.AvoidSystems.Clear();
-            refreshJumpRouteUI();
+            RecalculateCapitalRouteAndRefresh();
         }
 
         private void CopyRouteBtn_Click(object sender, RoutedEventArgs e)
@@ -424,18 +422,7 @@ namespace SMT
                double.TryParse(maxLYText, NumberStyles.Float, CultureInfo.InvariantCulture, out double maxLY))
             {
                 CapitalRoute.MaxLY = maxLY;
-                CapitalRoute.Recalculate();
-
-                if(CapitalRoute.CurrentRoute.Count == 0)
-                {
-                    lblCapitalRouteSummary.Content = "No Valid Route Found";
-                }
-                else
-                {
-                    lblCapitalRouteSummary.Content = $"{CapitalRoute.CurrentRoute.Count - 2} Mids";
-                }
-
-                refreshJumpRouteUI();
+                RecalculateCapitalRouteAndRefresh();
             }
         }
 
@@ -448,18 +435,7 @@ namespace SMT
                int.TryParse(jdcText, NumberStyles.Integer, CultureInfo.InvariantCulture, out int jdc))
             {
                 CapitalRoute.JDC = jdc;
-                CapitalRoute.Recalculate();
-
-                if(CapitalRoute.CurrentRoute.Count == 0)
-                {
-                    lblCapitalRouteSummary.Content = "No Valid Route Found";
-                }
-                else
-                {
-                    lblCapitalRouteSummary.Content = $"{CapitalRoute.CurrentRoute.Count - 2} Mids";
-                }
-
-                refreshJumpRouteUI();
+                RecalculateCapitalRouteAndRefresh();
             }
         }
 
@@ -485,28 +461,36 @@ namespace SMT
 
         private void CapitalWaypointsContextMenuMoveUp_Click(object sender, RoutedEventArgs e)
         {
-            if(capitalRouteWaypointsLB.SelectedItem != null && capitalRouteWaypointsLB.SelectedIndex != 0)
+            int selectedIndex = capitalRouteWaypointsLB.SelectedIndex;
+            if(selectedIndex > 0)
             {
-                string sys = CapitalRoute.WayPoints[capitalRouteWaypointsLB.SelectedIndex];
-                CapitalRoute.WayPoints.RemoveAt(capitalRouteWaypointsLB.SelectedIndex);
-                CapitalRoute.WayPoints.Insert(capitalRouteWaypointsLB.SelectedIndex - 1, sys);
-
-                CapitalRoute.Recalculate();
-                refreshJumpRouteUI();
+                MoveCapitalWaypoint(selectedIndex, selectedIndex - 1);
             }
         }
 
         private void CapitalWaypointsContextMenuMoveDown_Click(object sender, RoutedEventArgs e)
         {
-            if(capitalRouteWaypointsLB.SelectedItem != null && capitalRouteWaypointsLB.SelectedIndex != CapitalRoute.WayPoints.Count - 1)
+            int selectedIndex = capitalRouteWaypointsLB.SelectedIndex;
+            if(selectedIndex >= 0 && selectedIndex < CapitalRoute.WayPoints.Count - 1)
             {
-                string sys = CapitalRoute.WayPoints[capitalRouteWaypointsLB.SelectedIndex];
-                CapitalRoute.WayPoints.RemoveAt(capitalRouteWaypointsLB.SelectedIndex);
-                CapitalRoute.WayPoints.Insert(capitalRouteWaypointsLB.SelectedIndex + 1, sys);
-
-                CapitalRoute.Recalculate();
-                refreshJumpRouteUI();
+                MoveCapitalWaypoint(selectedIndex, selectedIndex + 1);
             }
+        }
+
+        private void MoveCapitalWaypoint(int sourceIndex, int targetIndex)
+        {
+            if(sourceIndex < 0 || targetIndex < 0 ||
+               sourceIndex >= CapitalRoute.WayPoints.Count || targetIndex >= CapitalRoute.WayPoints.Count ||
+               sourceIndex == targetIndex)
+            {
+                return;
+            }
+
+            string systemName = CapitalRoute.WayPoints[sourceIndex];
+            CapitalRoute.WayPoints.RemoveAt(sourceIndex);
+            CapitalRoute.WayPoints.Insert(targetIndex, systemName);
+            RecalculateCapitalRouteAndRefresh();
+            capitalRouteWaypointsLB.SelectedIndex = targetIndex;
         }
 
         private void CapitalWaypointsContextMenuDelete_Click(object sender, RoutedEventArgs e)
@@ -514,41 +498,104 @@ namespace SMT
             if(capitalRouteWaypointsLB.SelectedItem != null)
             {
                 CapitalRoute.WayPoints.RemoveAt(capitalRouteWaypointsLB.SelectedIndex);
-                CapitalRoute.Recalculate();
-                refreshJumpRouteUI();
+                RecalculateCapitalRouteAndRefresh();
             }
         }
 
         private void CapitalRouteContextMenuUseAlt_Click(object sender, RoutedEventArgs e)
         {
-            if(lbAlternateMids.SelectedItem != null)
+            if(lbAlternateMids.SelectedItem is string selectedAlt &&
+               lblAlternateMids.Content is string currentMid &&
+               !CapitalRoute.WayPoints.Contains(selectedAlt))
             {
-                string selectedAlt = lbAlternateMids.SelectedItem as string;
-
-                // need to find where to insert the new waypoint
-                int waypointIndex = -1;
+                int waypointIndex = 0;
                 foreach(Navigation.RoutePoint rp in CapitalRoute.CurrentRoute)
                 {
-                    if(rp.SystemName == CapitalRoute.WayPoints[waypointIndex + 1])
+                    if(waypointIndex + 1 < CapitalRoute.WayPoints.Count &&
+                       rp.SystemName == CapitalRoute.WayPoints[waypointIndex + 1])
                     {
                         waypointIndex++;
                     }
-                    if(CapitalRoute.AlternateMids.ContainsKey(rp.SystemName))
+
+                    if(rp.SystemName == currentMid)
                     {
-                        foreach(string alt in CapitalRoute.AlternateMids[rp.SystemName])
-                        {
-                            if(alt == selectedAlt)
-                            {
-                                CapitalRoute.WayPoints.Insert(waypointIndex + 1, selectedAlt);
-                                break;
-                            }
-                        }
+                        CapitalRoute.WayPoints.Insert(waypointIndex + 1, selectedAlt);
+                        RecalculateCapitalRouteAndRefresh();
+                        return;
                     }
                 }
-
-                CapitalRoute.Recalculate();
-                refreshJumpRouteUI();
             }
+        }
+
+        private void CopyCapitalRouteBtn_Click(object sender, RoutedEventArgs e)
+        {
+            if(CapitalRoute.CurrentRoute.Count == 0)
+            {
+                return;
+            }
+
+            var routeText = new System.Text.StringBuilder();
+            routeText.AppendLine("Capital Route");
+            routeText.AppendLine("=============");
+            foreach(Navigation.RoutePoint routePoint in CapitalRoute.CurrentRoute)
+            {
+                routeText.Append(routePoint.SystemName);
+                if(routePoint.LY > 0)
+                {
+                    routeText.Append(CultureInfo.CurrentCulture, $"  ({routePoint.LY:0.##} LY)");
+                }
+                routeText.AppendLine();
+            }
+
+            try
+            {
+                Clipboard.SetText(routeText.ToString());
+                lblCapitalRouteSummary.Content = GetResourceText("Main_JP_CopySuccess", "Route copied to the clipboard.");
+            }
+            catch(Exception exception)
+            {
+                EVEDataUtils.AppLog.Error("Copy capital route", exception);
+            }
+        }
+
+        private void CapitalWaypoints_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            capitalWaypointDragStart = e.GetPosition(capitalRouteWaypointsLB);
+            ListBoxItem item = ItemsControl.ContainerFromElement(capitalRouteWaypointsLB, e.OriginalSource as DependencyObject) as ListBoxItem;
+            draggedCapitalWaypoint = item?.DataContext as string;
+        }
+
+        private void CapitalWaypoints_PreviewMouseMove(object sender, MouseEventArgs e)
+        {
+            if(e.LeftButton != MouseButtonState.Pressed || string.IsNullOrEmpty(draggedCapitalWaypoint))
+            {
+                return;
+            }
+
+            Point currentPosition = e.GetPosition(capitalRouteWaypointsLB);
+            if(Math.Abs(currentPosition.X - capitalWaypointDragStart.X) < SystemParameters.MinimumHorizontalDragDistance &&
+               Math.Abs(currentPosition.Y - capitalWaypointDragStart.Y) < SystemParameters.MinimumVerticalDragDistance)
+            {
+                return;
+            }
+
+            DragDrop.DoDragDrop(capitalRouteWaypointsLB, draggedCapitalWaypoint, DragDropEffects.Move);
+        }
+
+        private void CapitalWaypoints_Drop(object sender, DragEventArgs e)
+        {
+            if(!e.Data.GetDataPresent(typeof(string)))
+            {
+                return;
+            }
+
+            string sourceSystem = e.Data.GetData(typeof(string)) as string;
+            ListBoxItem targetItem = ItemsControl.ContainerFromElement(capitalRouteWaypointsLB, e.OriginalSource as DependencyObject) as ListBoxItem;
+            string targetSystem = targetItem?.DataContext as string;
+            int sourceIndex = CapitalRoute.WayPoints.IndexOf(sourceSystem);
+            int targetIndex = string.IsNullOrEmpty(targetSystem) ? CapitalRoute.WayPoints.Count - 1 : CapitalRoute.WayPoints.IndexOf(targetSystem);
+            MoveCapitalWaypoint(sourceIndex, targetIndex);
+            draggedCapitalWaypoint = null;
         }
         private void btnUnseenFits_Click(object sender, RoutedEventArgs e)
         {

--- a/SMT/MainWindow.RoutingAndAnoms.cs
+++ b/SMT/MainWindow.RoutingAndAnoms.cs
@@ -441,11 +441,13 @@ namespace SMT
 
         private void JumpPlannerJDC_OnSelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if(CapitalRoute != null)
+            if(CapitalRoute != null &&
+               sender is ComboBox cb &&
+               cb.SelectedItem is ComboBoxItem cbi &&
+               cbi.DataContext is string jdcText &&
+               int.TryParse(jdcText, NumberStyles.Integer, CultureInfo.InvariantCulture, out int jdc))
             {
-                ComboBox cb = sender as ComboBox;
-                ComboBoxItem cbi = cb.SelectedItem as ComboBoxItem;
-                CapitalRoute.JDC = int.Parse(cbi.DataContext as string);
+                CapitalRoute.JDC = jdc;
                 CapitalRoute.Recalculate();
 
                 if(CapitalRoute.CurrentRoute.Count == 0)
@@ -463,9 +465,8 @@ namespace SMT
 
         private void CurrentCapitalRouteItem_Selected(object sender, RoutedEventArgs e)
         {
-            if(dgCapitalRouteCurrentRoute.SelectedItem != null)
+            if(dgCapitalRouteCurrentRoute.SelectedItem is Navigation.RoutePoint rp)
             {
-                Navigation.RoutePoint rp = dgCapitalRouteCurrentRoute.SelectedItem as Navigation.RoutePoint;
                 string sel = rp.SystemName;
 
                 UniverseUC.ShowSystem(sel);

--- a/SMT/MainWindow.RoutingAndAnoms.cs
+++ b/SMT/MainWindow.RoutingAndAnoms.cs
@@ -417,11 +417,13 @@ namespace SMT
         }
         private void JumpPlannerShipType_OnSelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if(CapitalRoute != null)
+            if(CapitalRoute != null &&
+               sender is ComboBox cb &&
+               cb.SelectedItem is ComboBoxItem cbi &&
+               cbi.DataContext is string maxLYText &&
+               double.TryParse(maxLYText, NumberStyles.Float, CultureInfo.InvariantCulture, out double maxLY))
             {
-                ComboBox cb = sender as ComboBox;
-                ComboBoxItem cbi = cb.SelectedItem as ComboBoxItem;
-                CapitalRoute.MaxLY = double.Parse(cbi.DataContext as string);
+                CapitalRoute.MaxLY = maxLY;
                 CapitalRoute.Recalculate();
 
                 if(CapitalRoute.CurrentRoute.Count == 0)

--- a/SMT/MainWindow.SovUpgrades.cs
+++ b/SMT/MainWindow.SovUpgrades.cs
@@ -104,7 +104,7 @@ namespace SMT
             string infoObjectsFile = Path.Combine(EveAppConfig.StorageRoot, "InfoObjects.txt");
             if(File.Exists(infoObjectsFile))
             {
-                StreamReader file = new StreamReader(infoObjectsFile);
+                using StreamReader file = new StreamReader(infoObjectsFile);
 
                 string line;
                 while((line = file.ReadLine()) != null)
@@ -117,7 +117,7 @@ namespace SMT
 
                     string[] parts = line.Split(',');
 
-                    if(parts.Length == 0)
+                    if(parts.Length < 2)
                     {
                         continue;
                     }
@@ -169,7 +169,10 @@ namespace SMT
 
                         Color c = (Color)ColorConverter.ConvertFromString(colour);
 
-                        int lineThickness = int.Parse(size);
+                        if(!int.TryParse(size, NumberStyles.Integer, CultureInfo.InvariantCulture, out int lineThickness))
+                        {
+                            continue;
+                        }
 
                         InfoItem ii = new InfoItem();
                         ii.DrawType = InfoItem.ShapeType.Line;
@@ -210,7 +213,10 @@ namespace SMT
 
                         Color c = (Color)ColorConverter.ConvertFromString(colour);
 
-                        int radius = int.Parse(size);
+                        if(!int.TryParse(size, NumberStyles.Integer, CultureInfo.InvariantCulture, out int radius))
+                        {
+                            continue;
+                        }
 
                         InfoItem ii = new InfoItem();
                         ii.DrawType = InfoItem.ShapeType.Circle;

--- a/SMT/MainWindow.xaml
+++ b/SMT/MainWindow.xaml
@@ -334,7 +334,7 @@
                                                             <ComboBoxItem DataContext="6.0" Content="{DynamicResource Main_JP_ShipAnsiblex}" />
                                                             <ComboBoxItem DataContext="6.0" Content="{DynamicResource Main_JP_ShipSuper}" />
                                                             <ComboBoxItem DataContext="7.0" IsSelected="True" Content="{DynamicResource Main_JP_ShipReg}" />
-                                                            <ComboBoxItem DataContext="7.5" IsSelected="True" Content="{DynamicResource Main_JP_ShipCommandCarrier}" />
+                                                            <ComboBoxItem DataContext="7.5" Content="{DynamicResource Main_JP_ShipCommandCarrier}" />
                                                             <ComboBoxItem DataContext="8.0" Content="{DynamicResource Main_JP_ShipBlops}" />
                                                             <ComboBoxItem DataContext="10.0" Content="{DynamicResource Main_JP_ShipJF}" />
                                                         </ComboBox>

--- a/SMT/MainWindow.xaml
+++ b/SMT/MainWindow.xaml
@@ -100,6 +100,21 @@
             <StatusBarItem>
                 <TextBlock Text="{DynamicResource Main_Players}" />
             </StatusBarItem>
+            <Separator />
+            <StatusBarItem HorizontalAlignment="Stretch">
+                <TextBlock Text="{Binding StatusMessage}" ToolTip="{Binding LogFilePath}" MaxWidth="520" TextTrimming="CharacterEllipsis">
+                    <TextBlock.Style>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="Foreground" Value="LightGreen" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding StatusIsError}" Value="True">
+                                    <Setter Property="Foreground" Value="OrangeRed" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBlock.Style>
+                </TextBlock>
+            </StatusBarItem>
         </StatusBar>
 
         <xcad:DockingManager x:Name="dockManager">
@@ -350,7 +365,7 @@
                                             </GroupBox>
                                             <GroupBox Header="{DynamicResource Main_JP_GrpWP}">
                                                 <StackPanel Margin="4">
-                                                    <ListBox x:Name="capitalRouteWaypointsLB" ItemsSource="{Binding CapitalRoute.WayPoints}" MinHeight="50" Margin="2" AllowDrop="True">
+                                                    <ListBox x:Name="capitalRouteWaypointsLB" ItemsSource="{Binding CapitalRoute.WayPoints}" MinHeight="50" Margin="2" AllowDrop="True" PreviewMouseLeftButtonDown="CapitalWaypoints_PreviewMouseLeftButtonDown" PreviewMouseMove="CapitalWaypoints_PreviewMouseMove" Drop="CapitalWaypoints_Drop">
                                                         <ListBox.ContextMenu>
                                                             <ContextMenu>
                                                                 <MenuItem Header="{DynamicResource Main_JP_CtxMoveUp}" Click="CapitalWaypointsContextMenuMoveUp_Click" />
@@ -429,6 +444,7 @@
                                                             <DataGridTextColumn Header="{DynamicResource Main_JP_ColDist}" Binding="{Binding LY, StringFormat={}{0:#.##}}" Width="8*" CanUserSort="False" />
                                                         </DataGrid.Columns>
                                                     </DataGrid>
+                                                    <Button x:Name="CopyCapitalRouteBtn" Click="CopyCapitalRouteBtn_Click" Content="{DynamicResource Main_Rte_BtnCopy}" Margin="2" />
                                                 </StackPanel>
                                             </GroupBox>
                                             <GroupBox Header="{DynamicResource Main_JP_GrpAlt}">

--- a/SMT/MainWindow.xaml.cs
+++ b/SMT/MainWindow.xaml.cs
@@ -25,6 +25,7 @@ using System.Windows.Threading;
 using System.Xml;
 using System.Xml.Serialization;
 using static SMT.EVEData.ZKillRedisQ;
+using EVEDataUtils;
 
 namespace SMT
 {
@@ -175,20 +176,7 @@ namespace SMT
 
             // Load the Dock Manager Layout file
             string dockManagerLayoutName = Path.Combine(EveAppConfig.StorageRoot, "Layout_" + WindowLayoutVersion + ".dat");
-            if(File.Exists(dockManagerLayoutName) && OperatingSystem.IsWindows())
-            {
-                try
-                {
-                    AvalonDock.Layout.Serialization.XmlLayoutSerializer ls = new(dockManager);
-                    using(var sr = new StreamReader(dockManagerLayoutName))
-                    {
-                        ls.Deserialize(sr);
-                    }
-                }
-                catch
-                {
-                }
-            }
+            LoadWindowLayoutWithBackup(dockManagerLayoutName);
 
             // Due to bugs in the Dock manager patch up the content id's for the 2 main views
             RegionLayoutDoc = FindDocWithContentID(dockManager.Layout, "MapRegionContentID");
@@ -199,15 +187,8 @@ namespace SMT
 
             if(File.Exists(mapConfigFileName))
             {
-                try
-                {
-                    XmlSerializer xms = new XmlSerializer(typeof(MapConfig));
-                    using FileStream fs = new FileStream(mapConfigFileName, FileMode.Open);
-                    using XmlReader xmlr = XmlReader.Create(fs);
-
-                    MapConf = (MapConfig)xms.Deserialize(xmlr);
-                }
-                catch
+                MapConf = Serialization.DeserializeFromDisk<MapConfig>(mapConfigFileName);
+                if(MapConf == null)
                 {
                     MapConf = new MapConfig();
                     MapConf.SetDefaultColours();
@@ -227,6 +208,10 @@ namespace SMT
             // Create the main EVE manager
 
             CapitalRoute = new JumpRoute();
+            capitalRouteWaypointsLB.ItemsSource = CapitalRoute.WayPoints;
+            capitalRouteAvoidLB.ItemsSource = CapitalRoute.AvoidSystems;
+            dgCapitalRouteCurrentRoute.ItemsSource = CapitalRoute.CurrentRoute;
+            RecalculateCapitalRouteAndRefresh();
 
             EVEManager = new EVEData.EveManager(EveAppConfig.SMT_VERSION);
             EVEData.EveManager.Instance = EVEManager;
@@ -357,23 +342,18 @@ namespace SMT
                         }
                     }
                 }
-                catch { }
+                catch(Exception exception)
+                {
+                    AppLog.Error("Load custom universe layout", exception);
+                }
             }
 
             // load the anom data
             string anomDataFilename = EVEManager.SaveDataVersionFolder + @"\Anoms.dat";
             if(File.Exists(anomDataFilename))
             {
-                try
-                {
-                    XmlSerializer xms = new XmlSerializer(typeof(EVEData.AnomManager));
-
-                    using FileStream fs = new FileStream(anomDataFilename, FileMode.Open);
-                    using XmlReader xmlr = XmlReader.Create(fs);
-
-                    ANOMManager = (EVEData.AnomManager)xms.Deserialize(xmlr);
-                }
-                catch
+                ANOMManager = Serialization.DeserializeFromDisk<EVEData.AnomManager>(anomDataFilename);
+                if(ANOMManager == null)
                 {
                     ANOMManager = new EVEData.AnomManager();
                 }
@@ -403,6 +383,8 @@ namespace SMT
             RegionsViewUC.RequestRegion += RegionsViewUC_RequestRegion;
 
             AppStatusBar.DataContext = EVEManager.ServerInfo;
+            EVEManager.ServerInfo.StatusMessage = "Ready";
+            AppLog.StatusChanged += AppLog_StatusChanged;
 
             List<EVEData.System> globalSystemList = new List<EVEData.System>(EVEManager.Systems);
             globalSystemList.Sort((a, b) => string.Compare(a.Name, b.Name));
@@ -503,7 +485,7 @@ namespace SMT
             nIcon.ContextMenuStrip.Items.Add("Show", null, NIcon_DClick);
             nIcon.ContextMenuStrip.Items.Add("Exit", null, NIcon_Exit);
 
-            CheckGitHubVersion();
+            _ = CheckGitHubVersionAsync();
 
             RegionUC.SelectRegion(MapConf.DefaultRegion);
         }

--- a/SMT/MainWindow.xaml.cs
+++ b/SMT/MainWindow.xaml.cs
@@ -202,11 +202,10 @@ namespace SMT
                 try
                 {
                     XmlSerializer xms = new XmlSerializer(typeof(MapConfig));
-                    FileStream fs = new FileStream(mapConfigFileName, FileMode.Open);
-                    XmlReader xmlr = XmlReader.Create(fs);
+                    using FileStream fs = new FileStream(mapConfigFileName, FileMode.Open);
+                    using XmlReader xmlr = XmlReader.Create(fs);
 
                     MapConf = (MapConfig)xms.Deserialize(xmlr);
-                    fs.Close();
                 }
                 catch
                 {
@@ -334,15 +333,19 @@ namespace SMT
                 {
                     using(TextReader tr = new StreamReader(customLayoutFile))
                     {
-                        string line = tr.ReadLine();
-
-                        while(line != null)
+                        string line;
+                        while((line = tr.ReadLine()) != null)
                         {
                             string[] bits = line.Split(',');
+                            if(bits.Length < 4 ||
+                               !double.TryParse(bits[2], NumberStyles.Float, CultureInfo.InvariantCulture, out double x) ||
+                               !double.TryParse(bits[3], NumberStyles.Float, CultureInfo.InvariantCulture, out double y))
+                            {
+                                continue;
+                            }
+
                             string region = bits[0];
                             string system = bits[1];
-                            double x = double.Parse(bits[2]);
-                            double y = double.Parse(bits[3]);
 
                             EVEData.System sys = EVEManager.GetEveSystem(system);
                             if(sys != null)
@@ -351,8 +354,6 @@ namespace SMT
                                 sys.UniverseY = y;
                                 sys.CustomUniverseLayout = true;
                             }
-
-                            line = tr.ReadLine();
                         }
                     }
                 }
@@ -367,11 +368,10 @@ namespace SMT
                 {
                     XmlSerializer xms = new XmlSerializer(typeof(EVEData.AnomManager));
 
-                    FileStream fs = new FileStream(anomDataFilename, FileMode.Open);
-                    XmlReader xmlr = XmlReader.Create(fs);
+                    using FileStream fs = new FileStream(anomDataFilename, FileMode.Open);
+                    using XmlReader xmlr = XmlReader.Create(fs);
 
                     ANOMManager = (EVEData.AnomManager)xms.Deserialize(xmlr);
-                    fs.Close();
                 }
                 catch
                 {

--- a/SMT/Overlay.xaml.cs
+++ b/SMT/Overlay.xaml.cs
@@ -689,6 +689,14 @@ namespace SMT
 
         private void Overlay_Closing(object sender, CancelEventArgs e)
         {
+            locationUpdateTimer.Stop();
+            dataUpdateTimer.Stop();
+            locationUpdateTimer.Tick -= UpdatePlayerLocations;
+            dataUpdateTimer.Tick -= UpdateDataOverlay;
+            mainWindow.OnSelectedCharChangedEventHandler -= SelectedCharChanged;
+            mainWindow.MapConf.PropertyChanged -= OverlayConf_PropertyChanged;
+            SizeChanged -= OnSizeChanged;
+            overlay_Canvas.SizeChanged -= OnCanvasSizeChanged;
             StoreOverlayWindowPosition();
         }
 

--- a/SMT/Preferences.xaml
+++ b/SMT/Preferences.xaml
@@ -8,7 +8,7 @@
         xmlns:conv="clr-namespace:SMT.Converters"
         mc:Ignorable="d"
         Name="PrefsWindow"
-        Title="{DynamicResource Prefs_Title}" SizeToContent="WidthAndHeight" WindowStartupLocation="CenterOwner" ResizeMode="NoResize" Loaded="Window_Loaded">
+        Title="{DynamicResource Prefs_Title}" SizeToContent="WidthAndHeight" WindowStartupLocation="CenterOwner" ResizeMode="NoResize" Loaded="Window_Loaded" Closed="Window_Closed">
     <Window.Resources>
         <conv:JoinStringConverter x:Key="stringJoiner" />
         <conv:NegateBooleanConverter x:Key="NegateBooleanConverter" />

--- a/SMT/Preferences.xaml.cs
+++ b/SMT/Preferences.xaml.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Text.RegularExpressions;
-using System.Threading;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Data;
 
@@ -29,10 +29,17 @@ namespace SMT
         private AudioFileReader audioFileReader;
 
         private bool isInitialLoad = true; // Flag to track initial load of preferences window
+        private readonly System.Windows.Threading.DispatcherTimer mapRedrawDebounceTimer;
 
         public PreferencesWindow()
         {
             InitializeComponent();
+
+            mapRedrawDebounceTimer = new System.Windows.Threading.DispatcherTimer
+            {
+                Interval = TimeSpan.FromMilliseconds(120),
+            };
+            mapRedrawDebounceTimer.Tick += MapRedrawDebounceTimer_Tick;
 
             syncESIPositionChk.IsChecked = EveManager.Instance.UseESIForCharacterPositions;
 
@@ -131,8 +138,7 @@ namespace SMT
         {
             MapConf.SetDefaultColours();
             ColoursPropertyGrid.SelectedObject = MapConf.ActiveColourScheme;
-            MainWindow.AppWindow.RegionUC.ReDrawMap(true);
-            MainWindow.AppWindow.UniverseUC.ReDrawMap(true, true, true);
+            ScheduleMapRedraw();
         }
 
         private void Window_Loaded(object sender, RoutedEventArgs e)
@@ -147,6 +153,18 @@ namespace SMT
 
         private void ColoursPropertyGrid_PropertyValueChanged(object sender, Xceed.Wpf.Toolkit.PropertyGrid.PropertyValueChangedEventArgs e)
         {
+            ScheduleMapRedraw();
+        }
+
+        private void ScheduleMapRedraw()
+        {
+            mapRedrawDebounceTimer.Stop();
+            mapRedrawDebounceTimer.Start();
+        }
+
+        private void MapRedrawDebounceTimer_Tick(object sender, EventArgs e)
+        {
+            mapRedrawDebounceTimer.Stop();
             MainWindow.AppWindow.RegionUC.ReDrawMap(true);
             MainWindow.AppWindow.UniverseUC.ReDrawMap(true, true, true);
         }
@@ -177,18 +195,45 @@ namespace SMT
 
         private void SetLogLocation_Click(object sender, RoutedEventArgs e)
         {
-            var dialog = new System.Windows.Forms.FolderBrowserDialog();
-            if(dialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+            using var dialog = new System.Windows.Forms.FolderBrowserDialog();
+            if(dialog.ShowDialog() != System.Windows.Forms.DialogResult.OK)
+            {
+                return;
+            }
+
+            if(EM.ReloadLogWatchers(dialog.SelectedPath))
             {
                 MapConf.CustomEveLogFolderLocation = dialog.SelectedPath;
+                MapConf.CurrentEveLogFolderLocation = EM.EVELogFolder;
+                MessageBox.Show("SMT is now monitoring the selected EVE log folder.", "Log Folder Updated", MessageBoxButton.OK, MessageBoxImage.Information);
             }
-            MessageBoxResult result = MessageBox.Show("Restart SMT for the log folder location to take effect", "Please Restart SMT", MessageBoxButton.OK);
+            else
+            {
+                MessageBox.Show("The selected folder must contain both Chatlogs and Gamelogs folders.", "Invalid EVE Log Folder", MessageBoxButton.OK, MessageBoxImage.Warning);
+            }
         }
 
         private void DefaultLogLocation_Click(object sender, RoutedEventArgs e)
         {
-            MapConf.CustomEveLogFolderLocation = string.Empty;
-            MessageBoxResult result = MessageBox.Show("Restart SMT for the log folder location to take effect", "Please Restart SMT", MessageBoxButton.OK);
+            if(EM.ReloadLogWatchers(string.Empty))
+            {
+                MapConf.CustomEveLogFolderLocation = string.Empty;
+                MapConf.CurrentEveLogFolderLocation = EM.EVELogFolder;
+                MessageBox.Show("SMT is now monitoring the default EVE log folder.", "Log Folder Updated", MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+            else
+            {
+                MessageBox.Show("The default EVE log folder could not be found.", "EVE Log Folder Not Found", MessageBoxButton.OK, MessageBoxImage.Warning);
+            }
+        }
+
+        private void Window_Closed(object sender, EventArgs e)
+        {
+            mapRedrawDebounceTimer.Stop();
+            mapRedrawDebounceTimer.Tick -= MapRedrawDebounceTimer_Tick;
+            waveOutEvent?.Stop();
+            waveOutEvent?.Dispose();
+            audioFileReader?.Dispose();
         }
 
         private void ClearJumpGatesBtn_Click(object sender, RoutedEventArgs e)
@@ -281,103 +326,65 @@ namespace SMT
             ImportPasteJumpGatesBtn.IsEnabled = false;
             ExportJumpGatesBtn.IsEnabled = false;
 
-            foreach(EVEData.LocalCharacter c in EveManager.Instance.LocalCharacters)
+            try
             {
-                if(c.ESILinked)
+                foreach(EVEData.LocalCharacter character in EveManager.Instance.GetLocalCharactersCopy())
                 {
-                    // This should never be set due to https://developers.eveonline.com/blog/article/the-esi-api-is-a-shared-resource-do-not-abuse-it
-                    if(c.DeepSearchEnabled && GateSearchFilter.Text == " » ")
+                    if(!character.ESILinked)
                     {
-                        string chars = "abcdefghijklmnopqrstuvwxyz0123456789";
-                        string basesearch = " » ";
+                        continue;
+                    }
 
-                        foreach(char cc in chars)
+                    // Deep search deliberately remains opt-in because ESI search is a shared resource.
+                    if(character.DeepSearchEnabled && GateSearchFilter.Text == " » ")
+                    {
+                        const string characters = "abcdefghijklmnopqrstuvwxyz0123456789";
+                        const string baseSearch = " » ";
+
+                        foreach(char searchCharacter in characters)
                         {
-                            string search = basesearch + cc;
-                            List<EVEData.JumpBridge> jbl = await c.FindJumpGates(search);
-
-                            foreach(EVEData.JumpBridge jb in jbl)
-                            {
-                                bool found = false;
-
-                                foreach(EVEData.JumpBridge jbr in EveManager.Instance.JumpBridges)
-                                {
-                                    if((jb.From == jbr.From && jb.To == jbr.To) || (jb.From == jbr.To && jb.To == jbr.From))
-                                    {
-                                        found = true;
-                                    }
-                                }
-
-                                if(!found)
-                                {
-                                    EveManager.Instance.JumpBridges.Add(jb);
-                                }
-                            }
-
-                            Thread.Sleep(100);
+                            AddDiscoveredJumpBridges(await character.FindJumpGates(baseSearch + searchCharacter));
+                            await Task.Delay(TimeSpan.FromMilliseconds(100));
                         }
 
-                        foreach(char cc in chars)
+                        foreach(char searchCharacter in characters)
                         {
-                            string search = cc + basesearch;
-                            List<EVEData.JumpBridge> jbl = await c.FindJumpGates(search);
-
-                            foreach(EVEData.JumpBridge jb in jbl)
-                            {
-                                bool found = false;
-
-                                foreach(EVEData.JumpBridge jbr in EveManager.Instance.JumpBridges)
-                                {
-                                    if((jb.From == jbr.From && jb.To == jbr.To) || (jb.From == jbr.To && jb.To == jbr.From))
-                                    {
-                                        found = true;
-                                    }
-                                }
-
-                                if(!found)
-                                {
-                                    EveManager.Instance.JumpBridges.Add(jb);
-                                }
-                            }
-
-                            Thread.Sleep(100);
+                            AddDiscoveredJumpBridges(await character.FindJumpGates(searchCharacter + baseSearch));
+                            await Task.Delay(TimeSpan.FromMilliseconds(100));
                         }
                     }
                     else
                     {
-                        List<EVEData.JumpBridge> jbl = await c.FindJumpGates(GateSearchFilter.Text);
-
-                        foreach(EVEData.JumpBridge jb in jbl)
-                        {
-                            bool found = false;
-
-                            foreach(EVEData.JumpBridge jbr in EveManager.Instance.JumpBridges)
-                            {
-                                if((jb.From == jbr.From && jb.To == jbr.To) || (jb.From == jbr.To && jb.To == jbr.From))
-                                {
-                                    found = true;
-                                }
-                            }
-
-                            if(!found)
-                            {
-                                EveManager.Instance.JumpBridges.Add(jb);
-                            }
-                        }
+                        AddDiscoveredJumpBridges(await character.FindJumpGates(GateSearchFilter.Text));
                     }
                 }
+
+                EVEData.Navigation.ClearJumpBridges();
+                EVEData.Navigation.UpdateJumpBridges(EveManager.Instance.JumpBridges);
+                UpdateJumpBridgeSummary();
+                CollectionViewSource.GetDefaultView(JumpBridgeList.ItemsSource).Refresh();
             }
+            catch(Exception exception)
+            {
+                EVEDataUtils.AppLog.Error("Find jump gates", exception);
+                MessageBox.Show(this, exception.Message, "Jump gate search", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            finally
+            {
+                ImportJumpGatesBtn.IsEnabled = true;
+                ClearJumpGatesBtn.IsEnabled = true;
+                JumpBridgeList.IsEnabled = true;
+                ImportPasteJumpGatesBtn.IsEnabled = true;
+                ExportJumpGatesBtn.IsEnabled = true;
+            }
+        }
 
-            EVEData.Navigation.ClearJumpBridges();
-            EVEData.Navigation.UpdateJumpBridges(EveManager.Instance.JumpBridges);
-            UpdateJumpBridgeSummary();
-
-            ImportJumpGatesBtn.IsEnabled = true;
-            ClearJumpGatesBtn.IsEnabled = true;
-            JumpBridgeList.IsEnabled = true;
-            ImportPasteJumpGatesBtn.IsEnabled = true;
-            ExportJumpGatesBtn.IsEnabled = true;
-            CollectionViewSource.GetDefaultView(JumpBridgeList.ItemsSource).Refresh();
+        private static void AddDiscoveredJumpBridges(IEnumerable<EVEData.JumpBridge> jumpBridges)
+        {
+            foreach(EVEData.JumpBridge jumpBridge in jumpBridges)
+            {
+                EveManager.Instance.AddUpdateJumpBridge(jumpBridge.From, jumpBridge.To, jumpBridge.FromID);
+            }
         }
 
         private void ImportPasteJumpGatesBtn_Click(object sender, RoutedEventArgs e)

--- a/SMT/RegionControl.xaml.cs
+++ b/SMT/RegionControl.xaml.cs
@@ -3027,24 +3027,26 @@ namespace SMT
 
         private void AllianceKeyList_MouseDown(object sender, MouseButtonEventArgs e)
         {
-            Label obj = sender as Label;
-            string AllianceIDStr = obj.DataContext as string;
-            long AllianceID = long.Parse(AllianceIDStr);
+            if(sender is not Label { DataContext: string allianceIDText } ||
+               !long.TryParse(allianceIDText, out long allianceID))
+            {
+                return;
+            }
 
             if(e.ClickCount == 2)
             {
-                string AURL = $"https://zkillboard.com/region/{Region.ID}/alliance/{AllianceID}/";
+                string AURL = $"https://zkillboard.com/region/{Region.ID}/alliance/{allianceID}/";
                 System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(AURL) { UseShellExecute = true });
             }
             else
             {
-                if(SelectedAlliance == AllianceID)
+                if(SelectedAlliance == allianceID)
                 {
                     SelectedAlliance = 0;
                 }
                 else
                 {
-                    SelectedAlliance = AllianceID;
+                    SelectedAlliance = allianceID;
                 }
                 ReDrawMap(true);
             }

--- a/SMT/RegionControl.xaml.cs
+++ b/SMT/RegionControl.xaml.cs
@@ -4034,6 +4034,11 @@ namespace SMT
         /// <param name="e"></param>
         private void UiRefreshTimer_Tick(object sender, EventArgs e)
         {
+            if(!IsVisible)
+            {
+                return;
+            }
+
             if(currentJumpCharacter != "")
             {
                 foreach(LocalCharacter c in EM.LocalCharacters)
@@ -4045,10 +4050,7 @@ namespace SMT
                 }
             }
 
-            Application.Current.Dispatcher.Invoke((Action)(() =>
-            {
-                ReDrawMap(false);
-            }), DispatcherPriority.Normal);
+            ReDrawMap(false);
         }
 
         private struct GateHelper

--- a/SMT/RegionsViewControl.xaml.cs
+++ b/SMT/RegionsViewControl.xaml.cs
@@ -54,7 +54,10 @@ namespace SMT
 
         private void UiRefreshTimer_Tick(object sender, EventArgs e)
         {
-            Redraw(false);
+            if(IsVisible)
+            {
+                Redraw(false);
+            }
         }
 
         public void Redraw(bool redraw)

--- a/SMT/SMT.csproj
+++ b/SMT/SMT.csproj
@@ -38,7 +38,7 @@
     <ManifestKeyFile>SMT_TemporaryKey.pfx</ManifestKeyFile>
   </PropertyGroup>
   <PropertyGroup>
-    <GenerateManifests>true</GenerateManifests>
+    <GenerateManifests>false</GenerateManifests>
   </PropertyGroup>
   <PropertyGroup>
     <SignManifests>false</SignManifests>

--- a/SMT/UniverseControl.xaml.cs
+++ b/SMT/UniverseControl.xaml.cs
@@ -310,7 +310,6 @@ namespace SMT
         // Timer to Re-draw the map
         private System.Windows.Threading.DispatcherTimer uiRefreshTimer;
 
-        private int uiRefreshTimer_interval = 0;
 
         public void Init()
         {
@@ -541,23 +540,16 @@ namespace SMT
 
         private void UiRefreshTimer_Tick(object sender, EventArgs e)
         {
-            uiRefreshTimer_interval++;
-
-            bool FullRedraw = false;
-            bool FastUpdate = true;
-            bool DataRedraw = false;
-
-            if(uiRefreshTimer_interval == 4)
+            if(!IsVisible)
             {
-                uiRefreshTimer_interval = 0;
-                DataRedraw = false;
+                return;
             }
 
             if(FollowCharacterChk.IsChecked.HasValue && (bool)FollowCharacterChk.IsChecked)
             {
                 CentreMapOnActiveCharacter();
             }
-            ReDrawMap(FullRedraw, DataRedraw, FastUpdate);
+            ReDrawMap(false, false, true);
         }
 
         private void VHSystems_MouseClicked(object sender, RoutedEventArgs e)

--- a/SMT/UniverseControl.xaml.cs
+++ b/SMT/UniverseControl.xaml.cs
@@ -441,13 +441,17 @@ namespace SMT
 
         private void SetJumpRange_Click(object sender, RoutedEventArgs e)
         {
-            EVEData.System sys = ((System.Windows.FrameworkElement)((System.Windows.FrameworkElement)sender).Parent).DataContext as EVEData.System;
+            if(sender is not MenuItem mi ||
+               mi.Parent is not FrameworkElement parent ||
+               parent.DataContext is not EVEData.System sys ||
+               mi.DataContext is not string rangeText ||
+               !double.TryParse(rangeText, NumberStyles.Float, CultureInfo.InvariantCulture, out double LY))
+            {
+                return;
+            }
 
             VHRangeSpheres.ClearAllChildren();
             VHRangeHighlights.ClearAllChildren();
-
-            MenuItem mi = sender as MenuItem;
-            double LY = double.Parse(mi.DataContext as string);
 
             if(LY == -1.0)
             {
@@ -455,14 +459,7 @@ namespace SMT
                 return;
             }
 
-            foreach(KeyValuePair<string, decimal> kvp in activeJumpSpheres)
-            {
-                if(kvp.Key == sys.Name)
-                {
-                    activeJumpSpheres.Remove(kvp);
-                    break;
-                }
-            }
+            activeJumpSpheres.RemoveAll(kvp => kvp.Key == sys.Name);
 
             if(LY > 0)
             {


### PR DESCRIPTION
### Fixed

- Fixed https://github.com/Slazanger/SMT/issues/210: Selecting Super/Titan, Command Carrier, Black Ops, Jump Freighter, or Rorqual in the Jump Planner no longer crashes SMT.
- Fixed culture-dependent jump-range parsing and removed the duplicate default ship selection.
- Fixed https://github.com/Slazanger/SMT/issues/186: Decloak and combat notification settings now remain disabled after restarting SMT.
- Character settings are saved immediately when the Character Settings window is closed.
- Fixed failed ESI waypoint requests leaving route synchronization permanently stuck.
- Fixed several shutdown races involving background updates, file watchers, timers, and the zKill feed.
- Fixed concurrent access to character, alliance, intel, combat-log, and sovereignty data.
- Fixed duplicate jump bridges being added during ESI discovery.
- Fixed Jump Planner alternative midpoint insertion and waypoint reordering.
- Fixed invalid or missing faction-warfare systems interrupting the complete update.
- Fixed corrupted configuration or layout files preventing normal startup by loading the latest valid backup.
- Fixed resources remaining active after closing overlays, authentication windows, or SMT.

### Added

- Added atomic saving for character data, application settings, map layouts, anomaly data, jump bridges, and intel filters.
- Added automatic `.bak` backups and recovery for serialized application data.
- Added a rotating local diagnostic log at `%APPDATA%\SMT\Logs\SMT.log`.
- Added application status and error information to the main status bar.
- Added detailed Jump Planner summaries showing jumps, midpoints, total light-years, and failed route segments.
- Added drag-and-drop reordering for capital-route waypoints.
- Added duplicate prevention for waypoints and avoided systems.
- Added a button to copy the complete capital route to the clipboard.
- Added localized Jump Planner status messages for English and Chinese.

### Improved

- Replaced blocking background workers, `.Result`, `Thread.Sleep`, and unmanaged update threads with cancellable asynchronous tasks.
- Reworked the zKill feed to use a shared HTTP client, proper cancellation, rate-limit handling, expiration cleanup, and non-blocking alliance resolution.
- Improved ESI, EVE-Scout, Dotlan, sovereignty, and server-status update handling.
- Sovereignty campaigns are now updated in place on the UI thread instead of repeatedly rebuilding the complete collection.
- Optimized faction-warfare classification by replacing repeated list scans with indexed lookups.
- Improved character and alliance identity-cache thread safety.
- The EVE log folder can now be changed without restarting SMT.
- Switching log folders preserves current intel data, combat-log data, and configured filters.
- Map colour changes now use debounced redraws.
- Hidden map views no longer perform unnecessary periodic redraws.
- Overlay timers and event handlers are correctly released when an overlay closes.
- Improved cleanup of HTTP listeners, timers, audio devices, file watchers, HTTP clients, and the tray icon.
- Improved error reporting across loading, saving, authentication, routing, and background-update operations.

### Technical

- Confirmed that all active SMT solution projects target .NET 8.
- The bundled legacy `External/ESI.NET` source remains multi-targeted, including .NET 7, but is not part of the active SMT solution build.