### PR TITLE
Fix intermediate waypoints being pushed to the client twice

### DIFF
--- a/EVEData/LocalCharacter.cs
+++ b/EVEData/LocalCharacter.cs
@@ -863,6 +863,15 @@ namespace SMT.EVEData
                     {
                         lock (ActiveRouteLock)
                         {
+                            // Navigate returns both endpoints, so consecutive legs share the waypoint
+                            // joining them. Drop the copy already in the route and keep the incoming
+                            // one : only that one carries the gate type for the next hop.
+                            if (ActiveRoute.Count > 0 && sysList.Count > 0 &&
+                                ActiveRoute[ActiveRoute.Count - 1].SystemName == sysList[0].SystemName)
+                            {
+                                ActiveRoute.RemoveAt(ActiveRoute.Count - 1);
+                            }
+
                             foreach (Navigation.RoutePoint s in sysList)
                             {
                                 ActiveRoute.Add(s);
@@ -926,6 +935,12 @@ namespace SMT.EVEData
                                         }
                                     }
                                 }
+                                // the client refuses a waypoint that repeats the one before it
+                                if (WayPointsToAdd.Count > 0 && WayPointsToAdd[WayPointsToAdd.Count - 1] == wayPointSysID)
+                                {
+                                    continue;
+                                }
+
                                 WayPointsToAdd.Add(wayPointSysID);
                             }
                         }


### PR DESCRIPTION
### The bug

`Navigation.Navigate(from, to)` returns a route that includes **both** of its endpoints. `LocalCharacter.UpdateActiveRoute` routes one leg per waypoint and concatenates the results, so the waypoint joining two legs lands in `ActiveRoute` twice — once as the tail of leg N, once as the head of leg N+1:

```
leg 1 : Navigate(location, WP0) -> [ L, a, b, WP0 ]
leg 2 : Navigate(WP0,      WP1) -> [ WP0, c, WP1 ]
ActiveRoute                     -> [ L, a, b, WP0, WP0, c, WP1 ]
```

The ESI push list keeps every route point whose name is in `Waypoints`, so both copies of WP0 go out. The client refuses a waypoint that repeats the one before it and shows "cannot add a waypoint to the same location" — on every route with two or more waypoints.

Two smaller symptoms have the same cause: the route grid lists the joining system twice, and `ActiveRouteLength` counts it twice.

### The fix

When appending a leg, drop the point already at the end of `ActiveRoute` if the incoming leg starts with the same system.

The copy dropped is the stale one rather than the incoming one on purpose: only the head of leg N+1 carries the `GateToTake` for the next hop, so keeping the tail of leg N instead would silently lose Ansiblex / Thera / Turnur / Zarzakh routing on any waypoint the route passes through.

A second, smaller guard skips consecutive identical ids while building `WayPointsToAdd`. That covers the other way one system can yield the same id twice — the jump bridge lookup remapping a system id to its structure id.

### Testing

- Full solution builds clean on top of current master : 4 projects, 0 errors, 0 warnings.
- To reproduce: set a destination from the map, then add a second waypoint. Before the change the client rejects the duplicate on every route push, and the route grid shows the joining system twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
